### PR TITLE
drop `.record` suffix from impact claim

### DIFF
--- a/hypercert.json
+++ b/hypercert.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "org.hypercerts.claim.record",
+  "id": "org.hypercerts.claim",
   "defs": {
     "main": {
       "type": "record",

--- a/hypercertContribution.json
+++ b/hypercertContribution.json
@@ -13,7 +13,7 @@
           "hypercert": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "A strong reference to the hypercert this contribution is for. The record referenced must conform with the lexicon org.hypercerts.claim.record"
+            "description": "A strong reference to the hypercert this contribution is for. The record referenced must conform with the lexicon org.hypercerts.claim."
           },
           "role": {
             "type": "string",

--- a/hypercertMeasurement.json
+++ b/hypercertMeasurement.json
@@ -13,11 +13,11 @@
           "hypercert": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "A strong reference to the hypercert that this measurement is for. The record referenced must conform with the lexicon org.hypercerts.claim.record"
+            "description": "A strong reference to the hypercert that this measurement is for. The record referenced must conform with the lexicon org.hypercerts.claim."
           },
           "measurers": {
             "type": "array",
-            "description": "DIDs of the entity (or entities) that measured this data. ",
+            "description": "DIDs of the entity (or entities) that measured this data",
             "items": {
               "type": "string",
               "format": "did"


### PR DESCRIPTION
Every lexicon describes a record, so this bit is redundant.