### PR TITLE
Run lexicons through a lexicon validator

### DIFF
--- a/hypercert.json
+++ b/hypercert.json
@@ -55,6 +55,7 @@
             "type": "array",
             "description": "Supporting evidence, documentation, or external data URIs",
             "items": {
+              "type": "ref",
               "ref": "com.atproto.repo.strongRef",
               "description": "A strong reference to the evidence that supports this impact claim. The record referenced must conform with the org.hypercerts.claim.evidence lexicon"
             },
@@ -69,11 +70,13 @@
             }
           },
           "rights": {
+            "type": "ref",
             "ref": "com.atproto.repo.strongRef",
             "description": "A strong reference to the rights that this hypercert has. The record referenced must conform with the lexicon org.hypercerts.claim.rights"
           },
           "location": {
-           "ref": "com.atproto.repo.strongRef",
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
             "description": "A strong reference to the location where the work for done hypercert was located. The record referenced must conform with the lexicon org.hypercerts.claim.location"
           },
           "createdAt": {

--- a/hypercertEvidence.json
+++ b/hypercertEvidence.json
@@ -2,40 +2,42 @@
   "lexicon": 1,
   "id": "org.hypercerts.claim.evidence",
   "defs": {
-    "type": "record",
-    "description": "A piece of evidence supporting a hypercert claim",
-    "key": "any",
-    "record": {
-      "type": "object",
-      "required": ["content", "shortDescription", "createdAt"],
-      "properties": {
-        "content": {
-          "type": "union",
-          "refs": ["app.certified.defs#uri", "app.certified.defs#smallBlob"],
-          "description": "A piece of evidence (URI or blobs) supporting a hypercert claim"
-        },
-        "title": {
-          "type": "string",
-          "maxLength": 256,
-          "description": "Optional title to describe the nature of the evidence"
-        },
-        "shortDescription": {
-          "type": "string",
-          "maxLength": 3000,
-          "maxGraphemes": 300,
-          "description": "Short description explaining what this evidence demonstrates or proves"
-        },
-        "description": {
+    "main": {
+      "type": "record",
+      "description": "A piece of evidence supporting a hypercert claim",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["content", "shortDescription", "createdAt"],
+        "properties": {
+          "content": {
+            "type": "union",
+            "refs": ["app.certified.defs#uri", "app.certified.defs#smallBlob"],
+            "description": "A piece of evidence (URI or blobs) supporting a hypercert claim"
+          },
+          "title": {
             "type": "string",
-            "description": "Optional longer description describing the impact claim evidence.",
-            "maxLength": 30000,
-            "maxGraphemes": 3000
-        },
-        "createdAt": {
+            "maxLength": 256,
+            "description": "Optional title to describe the nature of the evidence"
+          },
+          "shortDescription": {
             "type": "string",
-            "format": "datetime",
-            "description": "Client-declared timestamp when this hypercert claim was originally created"
-          }
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "Short description explaining what this evidence demonstrates or proves"
+          },
+          "description": {
+              "type": "string",
+              "description": "Optional longer description describing the impact claim evidence.",
+              "maxLength": 30000,
+              "maxGraphemes": 3000
+          },
+          "createdAt": {
+              "type": "string",
+              "format": "datetime",
+              "description": "Client-declared timestamp when this hypercert claim was originally created"
+            }
+        }
       }
     }
   }


### PR DESCRIPTION
Forgot to run validation through my last few commits. 

Used @atproto/lex-cli to pass through the files to check for any issues with the lexicon format. 

<img width="1010" height="424" alt="Screenshot 2025-11-04 at 15 38 08" src="https://github.com/user-attachments/assets/0ceb4843-2452-4101-8739-3ef33822d5be" />
