### PR TITLE
Updates in `hypercertContribution`

### DIFF
--- a/hypercertContribution.json
+++ b/hypercertContribution.json
@@ -22,10 +22,9 @@
           },
           "contributors": {
             "type": "array",
-            "description": "List of DIDs identifying the contributors. If multiple are stored in the same hypercertContribution, then they would have the exact same role.",
+            "description": "List of the contributors (names, pseudonyms, or DIDs). If multiple contributors are stored in the same hypercertContribution, then they would have the exact same role.",
             "items": {
-              "type": "string",
-              "format": "did"
+              "type": "string"
             }
           },
           "description": {


### PR DESCRIPTION
If we want to make hypercerts v0.2 fully upgradable from v0.1, we need to also take into account the fact that in v0.1 there is only a "contributor list". 

For this reason, I've removed the "role" in hypercertsContribution, so if needed we can just have a list of all the contributors (that can have optional extra info on the roles and concrete description of the contribution if needed)