### PR TITLE
feat: change lexicon to use object for uri

### DIFF
--- a/lexicons/app/certified/defs.json
+++ b/lexicons/app/certified/defs.json
@@ -3,10 +3,16 @@
   "id": "app.certified.defs",
   "defs": {
     "uri": {
-      "type": "string",
-      "format": "uri",
-      "maxGraphemes": 1000,
-      "description": "URI to external data"
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "uri",
+          "maxGraphemes": 1000,
+          "description": "URI to external data"
+        }
+      },
+      "required": ["value"]
     },
     "smallBlob": {
       "type": "blob",


### PR DESCRIPTION
From the [lexicon specs documentation](https://atproto.com/specs/lexicon#union) on atproto:

> The schema definitions pointed to by a union must have type object or record. All the variants must be represented by a CBOR map (or JSON Object) and must include a $type field indicating the variant type. A union can not point to types query, procedure, subscription, unknown, blob, cid-link, array, params, token, ref, union, or any other currently defined types.

Converting  this also fixes the types generated by the lex-cli. Otherwise when we use a simple string for the uri instead of object we end up with this type:

```
content:
    | $Typed<AppCertifiedDefs.Uri>
    | $Typed<AppCertifiedDefs.SmallBlob>
    | { $type: string }
```
and `$Typed` looks like this:

```
export type $Typed<V, T extends string = string> = V & { $type: T }
```

So if uri is just a string we end up with the type as `string & {$type: "uri"}` which is impossible to fulfill
