### PR TITLE
make measurement::activity optional

### DIFF
--- a/ERD.puml
+++ b/ERD.puml
@@ -72,7 +72,7 @@ dataclass evidence {
 
 dataclass measurement {
     !if (SHOW_FIELDS == "true")
-    activity
+    activity?
     measurers[]
     metric
     value

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 | Property               | Type     | Required | Description                                                                   | Comments                                                                          |
 | ---------------------- | -------- | -------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `activity`             | `ref`    | ✅       | A strong reference to the activity that this measurement is for             | The record referenced must conform with the lexicon `org.hypercerts.claim.activity` |
+| `activity`             | `ref`    | ❌       | A strong reference to the activity that this measurement is for             | The record referenced must conform with the lexicon `org.hypercerts.claim.activity` |
 | `measurers`            | `array`  | ✅       | DIDs of the entity (or entities) that measured this data                      |                                                                                   |
 | `metric`               | `string` | ✅       | The metric being measured                                                     |                                                                                   |
 | `value`                | `string` | ✅       | The measured value                                                            |                                                                                   |

--- a/lexicons/org/hypercerts/claim/measurement.json
+++ b/lexicons/org/hypercerts/claim/measurement.json
@@ -8,7 +8,7 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["activity", "measurers", "metric", "value", "createdAt"],
+        "required": ["measurers", "metric", "value", "createdAt"],
         "properties": {
           "activity": {
             "type": "ref",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Activity field in measurements is now optional instead of required
  * Measurements can be submitted without an activity reference
  * Updated schema specifications and validation documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->