### PR TITLE
rename `workScope` `allOf`/`anyOf`/`noneOf` to `withinAllOf` etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,19 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 #### Properties
 
-| Property           | Type     | Required | Description                                                                         | Comments                                                       |
-| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `title`            | `string` | ✅       | Title of the hypercert                                                              |                                                                |
-| `shortDescription` | `string` | ✅       | Short blurb of the impact work done.                                                |                                                                |
-| `description`      | `string` | ❌       | Optional longer description of the impact work done.                                |                                                                |
-| `image`            | `union`  | ❌       | The hypercert visual representation as a URI or image blob                          |                                                                |
-| `workScope`        | `object` | ❌       | Logical scope of the work using label-based conditions                              | Object with `allOf`, `anyOf`, `noneOf` arrays of labels        |
-| `startDate`        | `string` | ✅       | When the work began                                                                 |                                                                |
-| `endDate`          | `string` | ✅       | When the work ended                                                                 |                                                                |
-| `contributions`    | `array`  | ❌       | A strong reference to the contributions done to create the impact in the hypercerts | References must conform to `org.hypercerts.claim.contribution` |
-| `rights`           | `ref`    | ❌       | A strong reference to the rights that this hypercert has                            | References must conform to `org.hypercerts.claim.rights`       |
-| `location`         | `ref`    | ❌       | A strong reference to the location where the work for done hypercert was located    | References must conform to `app.certified.location`            |
-| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                   |                                                                |
+| Property           | Type     | Required | Description                                                                         | Comments                                                                  |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `title`            | `string` | ✅       | Title of the hypercert                                                              |                                                                           |
+| `shortDescription` | `string` | ✅       | Short blurb of the impact work done.                                                |                                                                           |
+| `description`      | `string` | ❌       | Optional longer description of the impact work done.                                |                                                                           |
+| `image`            | `union`  | ❌       | The hypercert visual representation as a URI or image blob                          |                                                                           |
+| `workScope`        | `object` | ❌       | Logical scope of the work using label-based conditions                              | Object with `withinAllOf`, `withinAnyOf`, `withinNoneOf` arrays of labels |
+| `startDate`        | `string` | ✅       | When the work began                                                                 |                                                                           |
+| `endDate`          | `string` | ✅       | When the work ended                                                                 |                                                                           |
+| `contributions`    | `array`  | ❌       | A strong reference to the contributions done to create the impact in the hypercerts | References must conform to `org.hypercerts.claim.contribution`            |
+| `rights`           | `ref`    | ❌       | A strong reference to the rights that this hypercert has                            | References must conform to `org.hypercerts.claim.rights`                  |
+| `location`         | `ref`    | ❌       | A strong reference to the location where the work for done hypercert was located    | References must conform to `app.certified.location`                       |
+| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                   |                                                                           |
 
 ---
 

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -83,9 +83,9 @@
     },
     "workScope": {
       "type": "object",
-      "description": "Logical scope of the work using label-based conditions. All labels in `allOf` must apply; at least one label in `anyOf` must apply if provided; no label in `noneOf` may apply.",
+      "description": "Logical scope of the work using label-based conditions. All labels in `withinAllOf` must apply; at least one label in `withinAnyOf` must apply if provided; no label in `withinNoneOf` may apply.",
       "properties": {
-        "allOf": {
+        "withinAllOf": {
           "type": "array",
           "description": "Labels that MUST all hold for the scope to apply.",
           "items": {
@@ -93,7 +93,7 @@
           },
           "maxLength": 100
         },
-        "anyOf": {
+        "withinAnyOf": {
           "type": "array",
           "description": "Labels of which AT LEAST ONE must hold (optional). If omitted or empty, imposes no additional condition.",
           "items": {
@@ -101,7 +101,7 @@
           },
           "maxLength": 100
         },
-        "noneOf": {
+        "withinNoneOf": {
           "type": "array",
           "description": "Labels that MUST NOT hold for the scope to apply.",
           "items": {


### PR DESCRIPTION
Following discussion with @holkexyz and our AI overlords, make the subset relationship between the subject (`workScope`) and objects (values of the `allOf`/`anyOf`/`noneOf` properties) more explicit for maximum clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workScope label condition properties: renamed allOf to withinAllOf, anyOf to withinAnyOf, and noneOf to withinNoneOf for improved semantic clarity.
  * Updated activity claim property descriptions and removed Comments column from documentation table.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->