### PR TITLE
fix: patch `lex` CLI to properly exit on validation failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Patch lex-cli to fix validation exit code bug
+        run: |
+          sed -i 's|// skip|throw e;|g' node_modules/@atproto/lex-cli/dist/util.js
+
       - name: Run checks
         run: npm run check


### PR DESCRIPTION
Without this patch, the `lex` CLI exits with code 0 even when validation fails, causing CI to incorrectly report success.

This is a problem because validation failures should cause the CI workflow to fail, alerting developers to issues in their lexicon definitions.

This patch solves the problem by monkey-patching the `lex` CLI's `util.js` file to replace the `// skip` line with `throw e;`, ensuring that validation errors are properly propagated and cause the workflow to fail.

Co-authored-by: Cursor <noreply@cursor.sh>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to enhance test execution handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->