### PR TITLE
ci: allow Hypercerts Release Bot App to bypass branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,19 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate Release Bot App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
+          # Persist releasebot app credentials to ensure that the push
+          # below can bypass branch protection rules
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: true
           fetch-depth: 0
 
       # Branch validation: Only allow develop (beta) or main (stable)


### PR DESCRIPTION
Use and persist releasebot app credentials during checkout to ensure that the push of the beta release version bump commit can bypass branch protection rules.

This is a port of the same approach from the SDK repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow to improve deployment efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->