### PR TITLE
fix: publish beta releases to beta npm tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         if: env.RELEASE_TYPE == 'beta'
         # changeset publish will automatically use the beta tag when in
         # prerelease mode and will create git tags for the release
-        run: npm run release
+        run: npm run release -- --tag beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Previously, beta releases from the develop branch were incorrectly updating the `latest` npm tag instead of the `beta` tag. This caused all beta versions to appear as the default `latest` version on npm.

The fix explicitly passes `--tag beta` to changeset publish to ensure beta releases correctly update the `beta` npm tag only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the beta release process to ensure proper version tagging during distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->