### PR TITLE
Refactor activity schema and add hyperboard user/workscope lexicons

### DIFF
--- a/lexicons/app/hyperboard/user.json
+++ b/lexicons/app/hyperboard/user.json
@@ -1,0 +1,42 @@
+{
+  "lexicon": 1,
+  "id": "app.hyperboard.user",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A user record representing a contributor or participant.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The user's identifier, can be a DID or a simple name.",
+            "maxLength": 256
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The user's display name.",
+            "maxLength": 256
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the user.",
+            "maxLength": 3000
+          },
+          "img": {
+            "type": "union",
+            "refs": [
+              "org.hypercerts.defs#uri",
+              "org.hypercerts.defs#smallImage"
+            ],
+            "description": "The user's profile image as a URI or image blob."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/hyperboard/workscope.json
+++ b/lexicons/app/hyperboard/workscope.json
@@ -1,0 +1,24 @@
+{
+  "lexicon": 1,
+  "id": "app.hyperboard.workscope",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A work scope record defining the scope of work.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": [
+          "description"
+        ],
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A description of the work scope.",
+            "maxLength": 3000
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -12,8 +12,7 @@
           "title",
           "shortDescription",
           "createdAt",
-          "startDate",
-          "endDate"
+          "startDate"
         ],
         "properties": {
           "title": {
@@ -43,7 +42,8 @@
           },
           "workScope": {
             "type": "ref",
-            "ref": "#workScope"
+            "ref": "com.atproto.repo.strongRef",
+            "description": "A strong reference to the work scope record."
           },
           "startDate": {
             "type": "string",
@@ -55,12 +55,19 @@
             "format": "datetime",
             "description": "When the work ended"
           },
-          "contributions": {
+          "contributors": {
             "type": "array",
-            "description": "A strong reference to the contributions done to create the impact in the hypercerts. The record referenced must conform with the lexicon org.hypercerts.claim.contribution.",
+            "description": "An array of strong references to the contributors who performed the work. Each reference must point to a valid contributor record. The length of this array must match the length of contributorsWeights.",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"
+            }
+          },
+          "contributorsWeights": {
+            "type": "array",
+            "description": "An array of integers defining the contribution weight of each contributor in the contributors array. The index corresponds to the contributor at the same index in the contributors array. Both arrays must have the same length.",
+            "items": {
+              "type": "integer"
             }
           },
           "rights": {
@@ -86,51 +93,6 @@
             "format": "datetime",
             "description": "Client-declared timestamp when this record was originally created"
           }
-        }
-      }
-    },
-    "workScope": {
-      "type": "object",
-      "description": "Logical scope of the work using label-based conditions. All labels in `withinAllOf` must apply; at least one label in `withinAnyOf` must apply if provided; no label in `withinNoneOf` may apply.",
-      "properties": {
-        "withinAllOf": {
-          "type": "array",
-          "description": "Labels that MUST all hold for the scope to apply.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
-        },
-        "withinAnyOf": {
-          "type": "array",
-          "description": "Labels of which AT LEAST ONE must hold (optional). If omitted or empty, imposes no additional condition.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
-        },
-        "withinNoneOf": {
-          "type": "array",
-          "description": "Labels that MUST NOT hold for the scope to apply.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
-        }
-      }
-    },
-    "activityWeight": {
-      "type": "object",
-      "required": ["activity", "weight"],
-      "properties": {
-        "activity": {
-          "type": "ref",
-          "ref": "com.atproto.repo.strongRef",
-          "description": "A strong reference to a hypercert activity record. This activity must conform to the lexicon org.hypercerts.claim.activity"
-        },
-        "weight": {
-          "type": "string",
-          "description": "The relative weight/importance of this hypercert activity (stored as a string to avoid float precision issues). Weights can be any positive numeric values and do not need to sum to a specific total; normalization can be performed by the consuming application as needed."
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR refactors the `org.hypercerts.claim.activity` lexicon to better support weighted contributor tracking and introduces two new lexicons for hyperboard-specific records.

## Changes to `org.hypercerts.claim.activity`

### 1. Made `endDate` Optional
- Removed `endDate` from the `required` fields array
- Activities can now represent ongoing work without a defined end date
- `endDate` field remains available as an optional property

### 2. Renamed `contributions` → `contributors`
- Changed field name from `contributions` to `contributors` for clarity
- Field now explicitly represents people/entities rather than abstract contributions
- Still uses `com.atproto.repo.strongRef` array for references

### 3. Added `contributorsWeights` Field
- New integer array field to define contribution weights
- Each weight corresponds to the contributor at the same index in `contributors`
- Both arrays must have matching lengths (enforced by description, applications should validate)
- Enables proportional credit allocation among contributors

### 4. Changed `workScope` to `strongRef`
- Previously: `workScope` referenced an inline object definition with `withinAllOf`, `withinAnyOf`, `withinNoneOf` fields
- Now: `workScope` is a `com.atproto.repo.strongRef` pointing to an external work scope record
- Allows work scopes to be reusable records rather than inline definitions
- Pairs with the new `app.hyperboard.workscope` lexicon

### 5. Removed `activityWeight` Definition
- The `activityWeight` sub-definition has been removed from the lexicon
- This definition was not being used in the main record schema
- Can be reintroduced as a separate lexicon if needed

### 6. Removed Local `workScope` Definition
- Removed the inline `workScope` object definition
- This definition is no longer needed since `workScope` now uses `strongRef`

## New Lexicons

### `app.hyperboard.user`
Defines a user/contributor record with:
- **`name`** (string, required): User identifier - can be a DID or simple name
- **`displayName`** (string, optional): Human-readable display name
- **`description`** (string, optional): User bio/description
- **`img`** (union, optional): Profile image as URI or image blob (same format as activity images)

### `app.hyperboard.workscope`
Defines a work scope record with:
- **`description`** (string, required): Description of the work scope

## Migration Considerations

### Breaking Changes
- **Field rename**: `contributions` → `contributors`
  - Applications must update field references
  - Data migration required for existing records

- **`workScope` type change**: inline object → `strongRef`
  - Existing inline work scopes must be converted to separate records
  - Applications must create work scope records and update references

### Non-breaking Changes
- **`endDate` now optional**: Existing records with `endDate` remain valid
- **`contributorsWeights` is optional**: Can be added incrementally

## Use Cases

These changes enable several new use cases:

1. **Weighted Contribution Tracking**: Accurately represent proportional contributions (e.g., 60/40 split between two contributors)
2. **Ongoing Activities**: Create hypercerts for work in progress without artificial end dates
3. **Reusable Work Scopes**: Define work scopes once and reference them across multiple activities
4. **Rich User Profiles**: Link to detailed user records with names, descriptions, and avatars

## Testing Recommendations

- Validate that `contributors` and `contributorsWeights` arrays have matching lengths
- Test migration path for existing `contributions` → `contributors` data
- Test migration path for inline `workScope` objects → `strongRef` records
- Verify optional `endDate` handling in consuming applications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user profile schema with configurable name, display name, description, and image fields.
  * Introduced work scope entity for structured scope definitions.

* **Changes**
  * Updated activity records to support multiple contributors with individual weight assignments.
  * Removed end date requirement from activity records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->