### PR TITLE
Remove bidirectional project-activity link

### DIFF
--- a/.changeset/remove-bidirectional-project-link.md
+++ b/.changeset/remove-bidirectional-project-link.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Remove bidirectional project-activity link. Activities no longer include a `project` field reference. Projects continue to reference activities via the `activities` array, making the relationship unidirectional (project → activities only).

--- a/ERD.puml
+++ b/ERD.puml
@@ -65,7 +65,6 @@ dataclass activity <<largeBold>> #B4E5D0 {
     contributions[]?
     locations[]?
     rights?
-    project?
     createdAt
     !endif
 }
@@ -305,7 +304,6 @@ project::location --> location
 activity::contributions -l--> contribution
 activity::rights --> rights
 activity::locations --> location
-activity::project --> project
 
 contribution::contributors --> contributor : made by
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 | `contributions`    | `array`  | ❌       | A strong reference to the contributions done to create the impact in the hypercerts          | References must conform to `org.hypercerts.claim.contribution`            |
 | `rights`           | `ref`    | ❌       | A strong reference to the rights that this hypercert has                                     | References must conform to `org.hypercerts.claim.rights`                  |
 | `locations`        | `ref`    | ❌       | An array of strong references to the locations where the work for done hypercert was located | References must conform to `app.certified.location`                       |
-| `project`          | `string` | ❌       | A reference (AT-URI) to the project record that this activity is part of                     | References must conform to `org.hypercerts.claim.project`                 |
 | `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                            |                                                                           |
 
 #### Defs
@@ -427,7 +426,7 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 **Lexicon ID:** `org.hypercerts.claim.project`
 
-**Description:** A project that can include multiple activities, each of which may be linked to at most one project.
+**Description:** A project that can include multiple activities
 
 **Key:** `tid`
 

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -76,11 +76,6 @@
               "ref": "com.atproto.repo.strongRef"
             }
           },
-          "project": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "A reference (AT-URI) to the project record that this activity is part of. The record referenced must conform with the lexicon org.hypercerts.claim.project. This activity must also be referenced by the project, establishing a bidirectional link."
-          },
           "createdAt": {
             "type": "string",
             "format": "datetime",

--- a/lexicons/org/hypercerts/claim/project.json
+++ b/lexicons/org/hypercerts/claim/project.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A project that can include multiple activities, each of which may be linked to at most one project.",
+      "description": "A project that can include multiple activities",
       "key": "tid",
       "record": {
         "type": "object",


### PR DESCRIPTION
- Remove project field from activity lexicon
- Update project description to reflect unidirectional relationship
- Update README documentation to remove project field from activity properties table
- Update ERD diagrams to remove activity->project relationship arrow
- Add changeset for minor version bump

Closes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added changeset documenting relationship modifications.

* **Refactor**
  * Simplified the project-activity relationship from bidirectional to unidirectional. Activities no longer maintain direct project references; only projects reference their associated activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->