### PR TITLE
Add ATProto lexicon styleguide compliance check to CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,3 +31,12 @@ reviews:
           Use the diff to identify which files changed and verify synchronization accordingly.
           Check that lexicon IDs in JSON files match what's documented in README.md.
           Verify that entity names in ERD.puml match lexicon IDs (e.g., "activity" entity should correspond to org.hypercerts.claim.activity lexicon).
+
+      - name: "Lexicons styleguide compliance"
+        mode: warning
+        instructions: |
+          Files in /lexicons should be reviewed on compliance against the lexicon styleguide as documented here: https://atproto.com/guides/lexicon-style-guide
+
+          The developers could deviate from the styleguide if they have a good reason to do so, but they must document their deviation in the lexicon JSON file.
+
+          When deviations are detected and undocumented provide guidance on how to make the changes compliant.


### PR DESCRIPTION
Add a new warning-level custom check to verify lexicon files comply with the ATProto lexicon style guide (https://atproto.com/guides/lexicon-style-guide).

The check will warn when deviations are detected and provide guidance on making changes compliant. Developers can still deviate from the styleguide when they have good reasons, but should document such deviations.

Works on #66 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional Lexicons styleguide compliance check to the pre-merge validation pipeline. The new check mirrors the existing validation but reports issues as warnings and includes guidance for reviewing and documenting any deviations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->