### PR TITLE
feat: change workScope to strongRef in activity lexicon

### DIFF
--- a/.changeset/change-workscope-to-strongref.md
+++ b/.changeset/change-workscope-to-strongref.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Change workScope from inline object definition to strongRef in activity lexicon. This breaking change removes the workScope definition (withinAllOf, withinAnyOf, withinNoneOf properties) and changes the workScope property to reference an external record via strongRef, allowing for more flexible work scope definitions.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ const activityRecord = {
   $type: ACTIVITY_NSID,
   title: "My Impact Work",
   shortDescription: "Description here",
-  workScope: "Scope of work",
+  workScope: {
+    uri: "at://did:plc:alice/org.hypercerts.claim.workscope/abc123",
+    cid: "...",
+  },
   startDate: "2023-01-01T00:00:00Z",
   endDate: "2023-12-31T23:59:59Z",
   createdAt: new Date().toISOString(),
@@ -286,19 +289,19 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 #### Properties
 
-| Property           | Type     | Required | Description                                                                                  | Comments                                                                  |
-| ------------------ | -------- | -------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `title`            | `string` | ✅       | Title of the hypercert                                                                       |                                                                           |
-| `shortDescription` | `string` | ✅       | Short blurb of the impact work done.                                                         |                                                                           |
-| `description`      | `string` | ❌       | Optional longer description of the impact work done.                                         |                                                                           |
-| `image`            | `union`  | ❌       | The hypercert visual representation as a URI or image blob                                   |                                                                           |
-| `workScope`        | `object` | ❌       | Logical scope of the work using label-based conditions                                       | Object with `withinAllOf`, `withinAnyOf`, `withinNoneOf` arrays of labels |
-| `startDate`        | `string` | ❌       | When the work began                                                                          |                                                                           |
-| `endDate`          | `string` | ❌       | When the work ended                                                                          |                                                                           |
-| `contributions`    | `array`  | ❌       | A strong reference to the contributions done to create the impact in the hypercerts          | References must conform to `org.hypercerts.claim.contributor`             |
-| `rights`           | `ref`    | ❌       | A strong reference to the rights that this hypercert has                                     | References must conform to `org.hypercerts.claim.rights`                  |
-| `locations`        | `ref`    | ❌       | An array of strong references to the locations where the work for done hypercert was located | References must conform to `app.certified.location`                       |
-| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                            |                                                                           |
+| Property           | Type     | Required | Description                                                                                  | Comments                                                                             |
+| ------------------ | -------- | -------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `title`            | `string` | ✅       | Title of the hypercert                                                                       |                                                                                      |
+| `shortDescription` | `string` | ✅       | Short blurb of the impact work done.                                                         |                                                                                      |
+| `description`      | `string` | ❌       | Optional longer description of the impact work done.                                         |                                                                                      |
+| `image`            | `union`  | ❌       | The hypercert visual representation as a URI or image blob                                   |                                                                                      |
+| `workScope`        | `ref`    | ❌       | A strong reference to a record defining the scope of work                                    | The record referenced should describe the logical scope using label-based conditions |
+| `startDate`        | `string` | ❌       | When the work began                                                                          |                                                                                      |
+| `endDate`          | `string` | ❌       | When the work ended                                                                          |                                                                                      |
+| `contributions`    | `array`  | ❌       | A strong reference to the contributions done to create the impact in the hypercerts          | References must conform to `org.hypercerts.claim.contributor`                        |
+| `rights`           | `ref`    | ❌       | A strong reference to the rights that this hypercert has                                     | References must conform to `org.hypercerts.claim.rights`                             |
+| `locations`        | `ref`    | ❌       | An array of strong references to the locations where the work for done hypercert was located | References must conform to `app.certified.location`                                  |
+| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                            |                                                                                      |
 
 #### Defs
 

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -37,7 +37,8 @@
           },
           "workScope": {
             "type": "ref",
-            "ref": "#workScope"
+            "ref": "com.atproto.repo.strongRef",
+            "description": "A strong reference to a record defining the scope of work. The record referenced should describe the logical scope using label-based conditions."
           },
           "startDate": {
             "type": "string",
@@ -75,36 +76,6 @@
             "format": "datetime",
             "description": "Client-declared timestamp when this record was originally created"
           }
-        }
-      }
-    },
-    "workScope": {
-      "type": "object",
-      "description": "Logical scope of the work using label-based conditions. All labels in `withinAllOf` must apply; at least one label in `withinAnyOf` must apply if provided; no label in `withinNoneOf` may apply.",
-      "properties": {
-        "withinAllOf": {
-          "type": "array",
-          "description": "Labels that MUST all hold for the scope to apply.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
-        },
-        "withinAnyOf": {
-          "type": "array",
-          "description": "Labels of which AT LEAST ONE must hold (optional). If omitted or empty, imposes no additional condition.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
-        },
-        "withinNoneOf": {
-          "type": "array",
-          "description": "Labels that MUST NOT hold for the scope to apply.",
-          "items": {
-            "type": "string"
-          },
-          "maxLength": 100
         }
       }
     },


### PR DESCRIPTION
BREAKING CHANGE: workScope property in org.hypercerts.claim.activity now uses com.atproto.repo.strongRef instead of inline object definition. The workScope definition (withinAllOf, withinAnyOf, withinNoneOf) has been removed from the lexicon.

This allows for more flexible work scope definitions by referencing external records rather than embedding the structure directly.

Changes:
- Update workScope property to reference com.atproto.repo.strongRef
- Remove workScope definition from activity lexicon defs
- Update README.md documentation and examples
- Add changeset for version bump

Closes #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * workScope changed from an inline object to a cross-record reference (strongRef); inline withinAllOf/withinAnyOf/withinNoneOf definitions removed, altering how work scope is represented in activity claims.

* **Documentation**
  * Updated activity record examples, property table, and descriptive text to reflect the new workScope reference-based structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->