### PR TITLE
refactor!: remove unused activityWeight definition

### DIFF
--- a/.changeset/remove-activity-weight.md
+++ b/.changeset/remove-activity-weight.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Remove unused activityWeight definition from activity lexicon. This definition was not being used anywhere in the codebase and has been removed to simplify the schema.

--- a/README.md
+++ b/README.md
@@ -300,15 +300,6 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 | `locations`        | `ref`    | ❌       | An array of strong references to the locations where the work for done hypercert was located | References must conform to `app.certified.location`                       |
 | `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                            |                                                                           |
 
-#### Defs
-
-##### activityWeight
-
-| Property   | Type     | Required | Description                                                                                                                                                                                                                                                                   |
-| ---------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `activity` | `ref`    | ✅       | A strong reference to a hypercert activity record. This activity must conform to the lexicon org.hypercerts.claim.activity                                                                                                                                                    |
-| `weight`   | `string` | ✅       | The relative weight/importance of this hypercert activity (stored as a string to avoid float precision issues). Weights can be any positive numeric values and do not need to sum to a specific total; normalization can be performed by the consuming application as needed. |
-
 ---
 
 ### Hypercerts Contribution

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -107,21 +107,6 @@
           "maxLength": 100
         }
       }
-    },
-    "activityWeight": {
-      "type": "object",
-      "required": ["activity", "weight"],
-      "properties": {
-        "activity": {
-          "type": "ref",
-          "ref": "com.atproto.repo.strongRef",
-          "description": "A strong reference to a hypercert activity record. This activity must conform to the lexicon org.hypercerts.claim.activity"
-        },
-        "weight": {
-          "type": "string",
-          "description": "The relative weight/importance of this hypercert activity (stored as a string to avoid float precision issues). Weights can be any positive numeric values and do not need to sum to a specific total; normalization can be performed by the consuming application as needed."
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: activityWeight definition has been removed from org.hypercerts.claim.activity lexicon. This definition was not being used anywhere in the codebase.

The activityWeight type (which contained activity strongRef and weight fields) was a leftover from an earlier design and is no longer needed.

Changes:
- Remove activityWeight definition from activity lexicon defs
- Remove activityWeight documentation from README.md
- Add changeset for version bump

Closes #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused `activityWeight` definition from the activity lexicon schema and updated related documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->