### PR TITLE
Revert "fix: publish beta releases to beta npm tag"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         if: env.RELEASE_TYPE == 'beta'
         # changeset publish will automatically use the beta tag when in
         # prerelease mode and will create git tags for the release
-        run: npm run release -- --tag beta
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
This reverts commit a238d856b44ce049943b2490e3bc8d18b409100c which didn't work.  We'll just have to live with the bug that Changesets won't update the `beta` tag, only the `latest` tag.

Hopefully this bug won't persist once we have a stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the beta release workflow to adjust how prerelease tagging is applied during the publishing process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->