### PR TITLE
add logic model for workScope

### DIFF
--- a/.changeset/add-work-scope-logic.md
+++ b/.changeset/add-work-scope-logic.md
@@ -1,0 +1,29 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add work scope logic expression system with boolean operators
+
+**New Features:**
+
+- **Work scope logic AST (`org.hypercerts.defs`):**
+  - Added `org.hypercerts.defs#workScopeAll` (logical AND): requires all arguments to be satisfied, with recursive union support for nested expressions
+  - Added `org.hypercerts.defs#workScopeAny` (logical OR): requires at least one argument to be satisfied, with recursive union support for nested expressions
+  - Added `org.hypercerts.defs#workScopeNot` (logical NOT): negates an expression, with recursive union support for nested expressions
+  - Added `org.hypercerts.defs#workScopeAtom`: atomic reference to a scope tag record via strongRef
+  - All operators support recursive boolean logic expressions through union types in their `args`/`arg` properties, allowing nested combinations of `workScopeAll`, `workScopeAny`, `workScopeNot`, and `workScopeAtom`
+
+- **Work scope tag lexicon (`org.hypercerts.helper.workScopeTag`):**
+  - New record type for reusable scope atoms
+  - Fields: `createdAt`, `key`, `label` (required), `kind`, `description`, `parent`, `aliases`, `externalReference` (optional)
+  - Supports taxonomy/hierarchy via `parent` strongRef
+  - Supports external references via URI or blob
+
+- **Activity lexicon (`org.hypercerts.claim.activity`):**
+  - Added `org.hypercerts.claim.activity#workScope` field using a union type that references `org.hypercerts.defs#workScopeAll`, `org.hypercerts.defs#workScopeAny`, `org.hypercerts.defs#workScopeNot`, and `org.hypercerts.defs#workScopeAtom`
+  - Enables complex boolean logic expressions for work scope definitions with recursive nesting support
+  - Replaces simple strongRef approach with expressive AST-based system
+
+**Breaking Changes:**
+
+- The `workScope` field in `org.hypercerts.claim.activity` now expects a work scope logic expression instead of a simple strongRef. Existing records using the old format will need to be migrated to use the new AST structure.

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -23,7 +23,7 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 | `description`            | `string` | ❌       | Optional longer description of this activity claim, including context or interpretation. Rich text annotations may be provided via `descriptionFacets`. | maxLength: 30000, maxGraphemes: 3000 |
 | `descriptionFacets`      | `ref`    | ❌       | Rich text annotations for `description` (mentions, URLs, hashtags, etc).                                                                                |                                      |
 | `image`                  | `union`  | ❌       | The hypercert visual representation as a URI or image blob.                                                                                             |                                      |
-| `workScope`              | `ref`    | ❌       | A strong reference to a record defining the scope of work. The record referenced should describe the logical scope using label-based conditions.        |                                      |
+| `workScope`              | `union`  | ❌       | Work scope logic expression using boolean operators (all/any/not) and atomic scope references.                                                          |                                      |
 | `startDate`              | `string` | ❌       | When the work began                                                                                                                                     |                                      |
 | `endDate`                | `string` | ❌       | When the work ended                                                                                                                                     |                                      |
 | `contributors`           | `ref`    | ❌       | An array of contributor objects, each containing contributor information, weight, and contribution details.                                             |                                      |
@@ -198,13 +198,17 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 
 #### Defs
 
-| Def          | Type     | Description                               | Comments                                |
-| ------------ | -------- | ----------------------------------------- | --------------------------------------- |
-| `uri`        | `object` | Object containing a URI to external data  | Has `uri` property (string, format uri) |
-| `smallBlob`  | `object` | Object containing a blob to external data | Has `blob` property (blob, up to 10MB)  |
-| `largeBlob`  | `object` | Object containing a blob to external data | Has `blob` property (blob, up to 100MB) |
-| `smallImage` | `object` | Object containing a small image           | Has `image` property (blob, up to 5MB)  |
-| `largeImage` | `object` | Object containing a large image           | Has `image` property (blob, up to 10MB) |
+| Def             | Type     | Description                                                    | Comments                                |
+| --------------- | -------- | -------------------------------------------------------------- | --------------------------------------- |
+| `uri`           | `object` | Object containing a URI to external data                       | Has `uri` property (string, format uri) |
+| `smallBlob`     | `object` | Object containing a blob to external data                      | Has `blob` property (blob, up to 10MB)  |
+| `largeBlob`     | `object` | Object containing a blob to external data                      | Has `blob` property (blob, up to 100MB) |
+| `smallImage`    | `object` | Object containing a small image                                | Has `image` property (blob, up to 5MB)  |
+| `largeImage`    | `object` | Object containing a large image                                | Has `image` property (blob, up to 10MB) |
+| `workScopeAll`  | `object` | Logical AND operation: all arguments must be satisfied.        |                                         |
+| `workScopeAny`  | `object` | Logical OR operation: at least one argument must be satisfied. |                                         |
+| `workScopeNot`  | `object` | Logical NOT operation: the argument must not be satisfied.     |                                         |
+| `workScopeAtom` | `object` | Atomic scope reference: a strong reference to a scope record.  |                                         |
 
 ---
 

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -52,9 +52,14 @@
             "description": "The hypercert visual representation as a URI or image blob."
           },
           "workScope": {
-            "type": "ref",
-            "ref": "com.atproto.repo.strongRef",
-            "description": "A strong reference to a record defining the scope of work. The record referenced should describe the logical scope using label-based conditions."
+            "type": "union",
+            "refs": [
+              "org.hypercerts.defs#workScopeAll",
+              "org.hypercerts.defs#workScopeAny",
+              "org.hypercerts.defs#workScopeNot",
+              "org.hypercerts.defs#workScopeAtom"
+            ],
+            "description": "Work scope logic expression using boolean operators (all/any/not) and atomic scope references."
           },
           "startDate": {
             "type": "string",

--- a/lexicons/org/hypercerts/defs.json
+++ b/lexicons/org/hypercerts/defs.json
@@ -66,6 +66,94 @@
           "description": "Image (up to 10MB)"
         }
       }
+    },
+    "workScopeAll": {
+      "type": "object",
+      "required": ["op", "args"],
+      "description": "Logical AND operation: all arguments must be satisfied.",
+      "properties": {
+        "op": {
+          "type": "string",
+          "const": "all",
+          "description": "Operator type: 'all' (logical AND)"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "union",
+            "refs": [
+              "#workScopeAll",
+              "#workScopeAny",
+              "#workScopeNot",
+              "#workScopeAtom"
+            ]
+          },
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "Array of work scope expressions that must all be satisfied"
+        }
+      }
+    },
+    "workScopeAny": {
+      "type": "object",
+      "required": ["op", "args"],
+      "description": "Logical OR operation: at least one argument must be satisfied.",
+      "properties": {
+        "op": {
+          "type": "string",
+          "const": "any",
+          "description": "Operator type: 'any' (logical OR)"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "union",
+            "refs": [
+              "#workScopeAll",
+              "#workScopeAny",
+              "#workScopeNot",
+              "#workScopeAtom"
+            ]
+          },
+          "minLength": 1,
+          "maxLength": 100,
+          "description": "Array of work scope expressions, at least one of which must be satisfied"
+        }
+      }
+    },
+    "workScopeNot": {
+      "type": "object",
+      "required": ["op", "arg"],
+      "description": "Logical NOT operation: the argument must not be satisfied.",
+      "properties": {
+        "op": {
+          "type": "string",
+          "const": "not",
+          "description": "Operator type: 'not' (logical NOT)"
+        },
+        "arg": {
+          "type": "union",
+          "refs": [
+            "#workScopeAll",
+            "#workScopeAny",
+            "#workScopeNot",
+            "#workScopeAtom"
+          ],
+          "description": "Work scope expression that must not be satisfied"
+        }
+      }
+    },
+    "workScopeAtom": {
+      "type": "object",
+      "required": ["atom"],
+      "description": "Atomic scope reference: a strong reference to a scope record.",
+      "properties": {
+        "atom": {
+          "type": "ref",
+          "ref": "com.atproto.repo.strongRef",
+          "description": "Strong reference to an org.hypercerts.helper.workScopeTag record"
+        }
+      }
     }
   }
 }

--- a/lexicons/org/hypercerts/helper/workScopeTag.json
+++ b/lexicons/org/hypercerts/helper/workScopeTag.json
@@ -1,0 +1,65 @@
+{
+  "lexicon": 1,
+  "id": "org.hypercerts.helper.workScopeTag",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A reusable scope atom for work scope logic expressions. Scopes can represent topics, languages, domains, deliverables, methods, regions, tags, or other categorical labels.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["createdAt", "key", "label"],
+        "properties": {
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created"
+          },
+          "key": {
+            "type": "string",
+            "description": "Lowercase, hyphenated machine-readable key for this scope (e.g., 'ipfs', 'go-lang', 'filecoin').",
+            "maxLength": 120
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for this scope.",
+            "maxLength": 200
+          },
+          "kind": {
+            "type": "string",
+            "description": "Category type of this scope. Recommended values: topic, language, domain, method, tag.",
+            "maxLength": 50
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional longer description of this scope.",
+            "maxLength": 10000,
+            "maxGraphemes": 1000
+          },
+          "parent": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Optional strong reference to a parent scope record for taxonomy/hierarchy support."
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "maxLength": 50,
+            "description": "Optional array of alternative names or identifiers for this scope."
+          },
+          "externalReference": {
+            "type": "union",
+            "refs": [
+              "org.hypercerts.defs#uri",
+              "org.hypercerts.defs#smallBlob"
+            ],
+            "description": "Optional external reference for this scope as a URI or blob."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work scope definitions now support nested boolean logic (AND/OR/NOT) for expressive scope expressions.
  * Added reusable scope tag records with hierarchical parent relationships, metadata, aliases, and optional external references.

* **Breaking Changes**
  * Existing work scope values must be migrated to the new boolean-expression format to remain compatible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->