### PR TITLE
renaming fields to contributorIdentity and contributionWeight in activity claim

### DIFF
--- a/.changeset/refactor-contributions-structure.md
+++ b/.changeset/refactor-contributions-structure.md
@@ -2,25 +2,40 @@
 "@hypercerts-org/lexicon": minor
 ---
 
-Refactor contributions structure and split contributor lexicon
+Refactor contributions structure in activity lexicon
 
 **Breaking Changes:**
 
 - **Activity lexicon (`org.hypercerts.claim.activity`):**
   - Renamed `contributions` field to `contributors`
   - Replaced `contributions` array (array of strongRefs) with new `contributors` array containing contributor objects
-  - Each contributor object has three fields:
-    - `contributorInformation` (required): string (DID/identifier) or strongRef to `org.hypercerts.claim.contributorInformation#main`
-    - `weight` (optional): positive number (stored as string)
-    - `contributionDetails` (optional): string or strongRef to `org.hypercerts.claim.contributionDetails#main`
-  - Renamed internal `contribution` object type to `contributor`
-  - Renamed string wrapper defs: `contributorInformationString` → `contributorIdentity`, `contributionDetailsString` → `contributorRole`
-  - Updated `contributorRole` string limits: maxLength 10000, maxGraphemes 1000
+  - Each contributor object (`org.hypercerts.claim.activity#contributor`) has three fields:
+    - `contributorIdentity` (required): string (DID/identifier) or strongRef to a contributor information record
+    - `contributionWeight` (optional): positive numeric value stored as string
+    - `contributionDetails` (optional): string or strongRef to a contribution details record
+  - Added internal defs:
+    - `#contributor`: object type for contributor entries
+    - `#contributorIdentity`: string type for DID/identifier values
+    - `#contributorRole`: string type for contribution details (maxLength 10000, maxGraphemes 1000)
 
-- **Contributor lexicon (`org.hypercerts.claim.contributor`):**
-  - Split into two separate lexicon files:
-    - `org.hypercerts.claim.contributorInformation`: new lexicon file containing `identifier`, `displayName`, `image` (contributor profile information)
-    - `org.hypercerts.claim.contributionDetails`: new lexicon file containing `role`, `contributionDescription`, `startDate`, `endDate` (contribution-specific details)
-  - The original `org.hypercerts.claim.contributor` lexicon has been removed
+**Migration:**
 
-Existing contributions using the old structure will need to be migrated to the new format.
+Convert from array of strongRefs to array of contributor objects:
+
+```json
+// Before
+"contributions": [strongRef1, strongRef2]
+
+// After
+"contributors": [
+  {
+    "contributorIdentity": "did:example:123",
+    "contributionWeight": "1.5",
+    "contributionDetails": "Lead developer"
+  },
+  {
+    "contributorIdentity": strongRefToContributorInfo,
+    "contributionDetails": strongRefToContributionDetails
+  }
+]
+```

--- a/README.md
+++ b/README.md
@@ -281,3 +281,22 @@ const collectionRecord = {
 **Note**: Both `avatar` (up to 5MB) and `banner` (up to 10MB) fields
 are optional and support either embedded image blobs or URI references to
 external images.
+
+### Adding Locations to Activities
+
+The `locations` field in activity records is an array of strong references
+(`com.atproto.repo.strongRef`) pointing to `app.certified.location` records.
+Each strong reference contains two required fields:
+
+- `uri`: The ATProto URI of the location record (e.g., `at://did:plc:alice/app.certified.location/abc123`)
+- `cid`: The content identifier (CID) of the location record, ensuring referential integrity
+
+**Validation and Expectations**:
+
+- All location records referenced in the `locations` array must conform to the
+  `app.certified.location` lexicon schema
+- The `uri` field must be a valid ATProto URI pointing to an existing location record
+- The `cid` field must match the current CID of the referenced location record
+- The `locations` field is optional; activities can be created without location data
+- When using the sidecar pattern (same TID), ensure the location record is created
+  or updated alongside the activity record for consistency

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -35,11 +35,11 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 ##### contributor
 
-| Property                 | Type     | Required | Description                                                                                                                                                                                                                                                        |
-| ------------------------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `contributorInformation` | `union`  | ✅       | Contributor information as a string (DID or identifier) or strong reference to for instance org.hypercerts.claim.contributorInformation#main.                                                                                                                      |
-| `weight`                 | `string` | ❌       | The relative weight/importance of this contribution (stored as a string to avoid float precision issues). Must be a positive numeric value. Weights do not need to sum to a specific total; normalization can be performed by the consuming application as needed. |
-| `contributionDetails`    | `union`  | ❌       | Contribution details as a string or strong reference to org.hypercerts.claim.contributionDetails#main.                                                                                                                                                             |
+| Property              | Type     | Required | Description                                                                                                                                                                                                                                                        |
+| --------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `contributorIdentity` | `union`  | ✅       | Contributor identity as a string (DID or identifier) via org.hypercerts.claim.activity#contributorIdentity, or a strong reference to a contributor information record.                                                                                             |
+| `contributionWeight`  | `string` | ❌       | The relative weight/importance of this contribution (stored as a string to avoid float precision issues). Must be a positive numeric value. Weights do not need to sum to a specific total; normalization can be performed by the consuming application as needed. |
+| `contributionDetails` | `union`  | ❌       | Contribution details as a string via org.hypercerts.claim.activity#contributorRole, or a strong reference to a contribution details record.                                                                                                                        |
 
 ---
 

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -97,21 +97,21 @@
     },
     "contributor": {
       "type": "object",
-      "required": ["contributorInformation"],
+      "required": ["contributorIdentity"],
       "properties": {
-        "contributorInformation": {
+        "contributorIdentity": {
           "type": "union",
           "refs": ["#contributorIdentity", "com.atproto.repo.strongRef"],
-          "description": "Contributor information as a string (DID or identifier) or strong reference to for instance org.hypercerts.claim.contributorInformation#main."
+          "description": "Contributor identity as a string (DID or identifier) via org.hypercerts.claim.activity#contributorIdentity, or a strong reference to a contributor information record."
         },
-        "weight": {
+        "contributionWeight": {
           "type": "string",
           "description": "The relative weight/importance of this contribution (stored as a string to avoid float precision issues). Must be a positive numeric value. Weights do not need to sum to a specific total; normalization can be performed by the consuming application as needed."
         },
         "contributionDetails": {
           "type": "union",
           "refs": ["#contributorRole", "com.atproto.repo.strongRef"],
-          "description": "Contribution details as a string or strong reference to org.hypercerts.claim.contributionDetails#main."
+          "description": "Contribution details as a string via org.hypercerts.claim.activity#contributorRole, or a strong reference to a contribution details record."
         }
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contributor tracking now uses structured contributor objects with a required identity plus optional weight and details.
  * Activity records can include multiple locations and per-item weights.

* **Breaking Changes**
  * Field previously holding simple contributor references is now a contributors array of objects; migration guidance and examples included.
  * Some activity/location fields changed from single references to arrays.

* **Documentation**
  * Added migration examples and guidance for adding locations to activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->