### PR TITLE
feat: add location property to collections

### DIFF
--- a/.changeset/add-locations-to-collections.md
+++ b/.changeset/add-locations-to-collections.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add `location` property to collections. Collections can now reference a location record directly via strongRef. This replaces the sidecar pattern which was impractical since location records cannot be reused across multiple collections.

--- a/ERD.puml
+++ b/ERD.puml
@@ -187,8 +187,6 @@ dataclass rights {
 }
 
 ' org.hypercerts.claim.collection
-' Note: Collections can use app.certified.location as a sidecar
-' by creating a location record with the same TID
 dataclass collection {
     !if (SHOW_FIELDS == "true")
     type?
@@ -196,6 +194,7 @@ dataclass collection {
     shortDescription?
     description? (Leaflet ref)
     items[]
+    location?
     createdAt
     !endif
 }
@@ -293,6 +292,7 @@ measurement --> location
 
 collection::items --> activity
 collection::items --> collection : "recursive\nnesting"
+collection::location --> location
 
 activity::contributors -l--> contributorInformation
 activity::contributors --> contributionDetails

--- a/README.md
+++ b/README.md
@@ -298,5 +298,25 @@ Each strong reference contains two required fields:
 - The `uri` field must be a valid ATProto URI pointing to an existing location record
 - The `cid` field must match the current CID of the referenced location record
 - The `locations` field is optional; activities can be created without location data
-- When using the sidecar pattern (same TID), ensure the location record is created
-  or updated alongside the activity record for consistency
+
+### Adding Location to Collections
+
+Collections can include an optional `location` field to specify where the collection's activities were performed:
+
+```typescript
+const collectionRecord = {
+  $type: "org.hypercerts.claim.collection",
+  title: "Climate Action Projects",
+  shortDescription: "A collection of climate-related activities",
+  location: {
+    uri: "at://did:plc:alice/app.certified.location/xyz789",
+    cid: "...",
+  },
+  items: [
+    // ... collection items
+  ],
+  createdAt: new Date().toISOString(),
+};
+```
+
+The `location` field is a strong reference to an `app.certified.location` record containing the same `uri` and `cid` fields as described above for activities.

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -118,22 +118,23 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 ### `org.hypercerts.claim.collection`
 
-**Description:** A collection/group of items (activities and/or other collections). Collections support recursive nesting. Use app.certified.location as a sidecar (same TID) for location metadata.
+**Description:** A collection/group of items (activities and/or other collections). Collections support recursive nesting.
 
 **Key:** `tid`
 
 #### Properties
 
-| Property           | Type     | Required | Description                                                                                                  | Comments                           |
-| ------------------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
-| `type`             | `string` | ❌       | The type of this collection. Possible fields can be 'favorites', 'project', or any other type of collection. |                                    |
-| `title`            | `string` | ✅       | The title of this collection                                                                                 | maxLength: 800, maxGraphemes: 80   |
-| `shortDescription` | `string` | ❌       | Short summary of this collection, suitable for previews and list views                                       | maxLength: 3000, maxGraphemes: 300 |
-| `description`      | `ref`    | ❌       | Rich-text description, represented as a Leaflet linear document.                                             |                                    |
-| `avatar`           | `union`  | ❌       | The collection's avatar/profile image as a URI or image blob.                                                |                                    |
-| `banner`           | `union`  | ❌       | Larger horizontal image to display behind the collection view.                                               |                                    |
-| `items`            | `ref`    | ✅       | Array of items in this collection with optional weights.                                                     |                                    |
-| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                                            |                                    |
+| Property           | Type     | Required | Description                                                                                                                                                       | Comments                           |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `type`             | `string` | ❌       | The type of this collection. Possible fields can be 'favorites', 'project', or any other type of collection.                                                      |                                    |
+| `title`            | `string` | ✅       | The title of this collection                                                                                                                                      | maxLength: 800, maxGraphemes: 80   |
+| `shortDescription` | `string` | ❌       | Short summary of this collection, suitable for previews and list views                                                                                            | maxLength: 3000, maxGraphemes: 300 |
+| `description`      | `ref`    | ❌       | Rich-text description, represented as a Leaflet linear document.                                                                                                  |                                    |
+| `avatar`           | `union`  | ❌       | The collection's avatar/profile image as a URI or image blob.                                                                                                     |                                    |
+| `banner`           | `union`  | ❌       | Larger horizontal image to display behind the collection view.                                                                                                    |                                    |
+| `items`            | `ref`    | ✅       | Array of items in this collection with optional weights.                                                                                                          |                                    |
+| `location`         | `ref`    | ❌       | A strong reference to the location where this collection's activities were performed. The record referenced must conform with the lexicon app.certified.location. |                                    |
+| `createdAt`        | `string` | ✅       | Client-declared timestamp when this record was originally created                                                                                                 |                                    |
 
 #### Defs
 

--- a/lexicons/org/hypercerts/claim/collection.json
+++ b/lexicons/org/hypercerts/claim/collection.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A collection/group of items (activities and/or other collections). Collections support recursive nesting. Use app.certified.location as a sidecar (same TID) for location metadata.",
+      "description": "A collection/group of items (activities and/or other collections). Collections support recursive nesting.",
       "key": "tid",
       "record": {
         "type": "object",
@@ -54,6 +54,11 @@
               "type": "ref",
               "ref": "#item"
             }
+          },
+          "location": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "A strong reference to the location where this collection's activities were performed. The record referenced must conform with the lexicon app.certified.location."
           },
           "createdAt": {
             "type": "string",


### PR DESCRIPTION
Without this patch, collections (and hence projects) could only associate location metadata using a sidecar pattern (creating a location record with the same TID). This was documented in the previous changeset `document-location-sidecar-pattern.md`.

This turned out to be problematic because:

1. Location records cannot be reused across multiple collections or activities - each record is specific to one entity. This could be fixed by introducing a sidecar which points to a reusable location record; however this would be an unreasonable amount of extra complexity for this many-to-one relationship vs. a simple optional location property.

2. As a corollary, a location provided in one repository can't be used by a collection / project in another repository.

3. If a location record changed, there would be no easy way of spotting that the collection/project referred to an older version.

4. The argument for keeping collections/projects as minimal as possible with separate location data is inconsistent with our position that the "where" is a core part of the main Hypercerts activity claim lexicon, which already has a built-in `locations` array. If it's OK for activity records to internally specify the "where", then it should also be OK for collections of activities too. N.B. These locations are still always optional! If they're not needed or appropriate, they can simply be omitted.

This patch solves the problem by adding a direct location property to the collection lexicon as an optional strongRef. Collections can now reference location records the same way activities do, using a straightforward property rather than relying on matching TIDs.

This brings another advantage that anyone can optionally check whether the CID of a collection/project location has changed, and the owner(s) of a collection/project can optionally decide to update the location field with the new CID if they approve of the change.

The changes include:

- Add optional location field to collection lexicon (strongRef)
- Update ERD.puml with location property and relationship
- Update README.md with usage example for collection locations
- Remove sidecar pattern references from documentation
- Auto-regenerate SCHEMAS.md to reflect the schema changes

Co-authored-by: Claude (Anthropic AI) <claude@noreply.anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections can now directly reference a location record via a strong reference, eliminating the need for the previous sidecar pattern.

* **Documentation**
  * Updated collection documentation with examples and clarified location reference semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->