### PR TITLE
fix: convert union string variants to object types for ATProto spec compliance

### DIFF
--- a/.changeset/fix-union-string-variants-atproto-spec.md
+++ b/.changeset/fix-union-string-variants-atproto-spec.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Convert union string variants to object types to comply with ATProto specification. The `workScopeString`, `contributorIdentity`, and `contributorRole` types in `org.hypercerts.claim.activity` are now objects with a `value` property instead of raw strings. This breaking change ensures all union variants are properly typed objects that can include the required `$type` discriminator field per the ATProto spec.

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -41,6 +41,24 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 | `contributionWeight`  | `string` | ❌       | The relative weight/importance of this contribution (stored as a string to avoid float precision issues). Must be a positive numeric value. Weights do not need to sum to a specific total; normalization can be performed by the consuming application as needed. |
 | `contributionDetails` | `union`  | ❌       | Contribution details as a string via org.hypercerts.claim.activity#contributorRole, or a strong reference to a contribution details record.                                                                                                                        |
 
+##### contributorIdentity
+
+| Property | Type     | Required | Description                       |
+| -------- | -------- | -------- | --------------------------------- |
+| `value`  | `string` | ✅       | The contributor DID or identifier |
+
+##### contributorRole
+
+| Property | Type     | Required | Description                      |
+| -------- | -------- | -------- | -------------------------------- |
+| `value`  | `string` | ✅       | The contribution role or details |
+
+##### workScopeString
+
+| Property | Type     | Required | Description                |
+| -------- | -------- | -------- | -------------------------- |
+| `value`  | `string` | ✅       | The work scope description |
+
 ---
 
 ### `org.hypercerts.claim.evaluation`

--- a/lexicons/org/hypercerts/claim/activity.json
+++ b/lexicons/org/hypercerts/claim/activity.json
@@ -116,20 +116,41 @@
       }
     },
     "contributorIdentity": {
-      "type": "string",
-      "description": "Contributor information as a string (DID or identifier)."
+      "type": "object",
+      "required": ["value"],
+      "description": "Contributor information as a string (DID or identifier).",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The contributor DID or identifier"
+        }
+      }
     },
     "contributorRole": {
-      "type": "string",
+      "type": "object",
+      "required": ["value"],
       "description": "Contribution details as a string.",
-      "maxLength": 10000,
-      "maxGraphemes": 1000
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The contribution role or details",
+          "maxLength": 10000,
+          "maxGraphemes": 1000
+        }
+      }
     },
     "workScopeString": {
-      "type": "string",
+      "type": "object",
+      "required": ["value"],
       "description": "A free-form string describing the work scope for simple or legacy scopes.",
-      "maxLength": 10000,
-      "maxGraphemes": 1000
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The work scope description",
+          "maxLength": 10000,
+          "maxGraphemes": 1000
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes union type definitions in `org.hypercerts.claim.activity` lexicon to comply with the ATProto specification. The spec requires that all union variants must be `object` or `record` types with a `$type` field, but three types were defined as raw strings.

## Changes

Converted three string-based union variants to object wrappers:

1. **`workScopeString`** - Now an object with a `value` property containing the work scope description
2. **`contributorIdentity`** - Now an object with a `value` property containing the DID or identifier  
3. **`contributorRole`** - Now an object with a `value` property containing the role details

### Before
```typescript
workScopeString: string
contributorIdentity: string
contributorRole: string
```

### After
```typescript
workScopeString: { value: string }
contributorIdentity: { value: string }
contributorRole: { value: string }
```

## Rationale

Per the [ATProto Lexicon Specification](https://atproto.com/specs/lexicon#union):

> *"The schema definitions pointed to by a union must have type object or record"*

All union variants must:
- Be objects or records (not primitive types)
- Support the `$type` discriminator field
- Properly serialize to CBOR/JSON with type information

Using raw strings in unions violated this requirement and could cause issues with type discrimination and validation in ATProto implementations.

Also prevents this type issue:

`Type 'string' is not assignable to type '$Typed<string>`

## Breaking Changes

**Migration required:**
- `activity.workScope` → `activity.workScope.value`
- `contributor.contributorIdentity` → `contributor.contributorIdentity.value`
- `contributor.contributionDetails` → `contributor.contributionDetails.value`

## Files Changed

- `lexicons/org/hypercerts/claim/activity.json` - Updated type definitions
- `SCHEMAS.md` - Auto-generated documentation updated
- `.changeset/fix-union-string-variants-atproto-spec.md` - Changeset added