### PR TITLE
edit lexicon style guide so that all union variants must be object or…

### DIFF
--- a/LEXICON_STYLE_GUIDE.md
+++ b/LEXICON_STYLE_GUIDE.md
@@ -52,7 +52,7 @@ This document summarizes the ATProto Lexicon Style Guide rules that are checked 
 - **Primitives**: Use appropriate primitive types (string, integer, boolean)
 - **Formats**: Apply format constraints (datetime, uri, cid, did, etc.)
 - **Refs**: Use refs for reusable types and relationships
-- **Unions**: Use unions when a property can be one of several types
+- **Unions**: Use unions when a property can be one of several types. All variants in a union must be object or record types (strings/numbers are not allowed directly in unions by ATProto spec).
 
 #### Constraints
 


### PR DESCRIPTION
… record types

Inspired by @Kzoeps 's PR
https://github.com/hypercerts-org/hypercerts-lexicon/pull/126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Unions guideline in the style guide with specific constraints requiring all union variants to be object or record types, excluding strings and numbers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->