### PR TITLE
feat: add profile lexicon

### DIFF
--- a/.changeset/add-profile-lexicon.md
+++ b/.changeset/add-profile-lexicon.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add profile lexicon for Hypercert account profiles with support for display name, description, pronouns, website, avatar, banner.

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -370,6 +370,26 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 
 ---
 
+### `app.certified.profile`
+
+**Description:** A declaration of a Hypercert account profile.
+
+**Key:** `literal:self`
+
+#### Properties
+
+| Property      | Type     | Required | Description                                                                    | Comments                           |
+| ------------- | -------- | -------- | ------------------------------------------------------------------------------ | ---------------------------------- |
+| `displayName` | `string` | ❌       |                                                                                | maxLength: 640, maxGraphemes: 64   |
+| `description` | `string` | ❌       | Free-form profile description text.                                            | maxLength: 2560, maxGraphemes: 256 |
+| `pronouns`    | `string` | ❌       | Free-form pronouns text.                                                       | maxLength: 200, maxGraphemes: 20   |
+| `website`     | `string` | ❌       |                                                                                |                                    |
+| `avatar`      | `union`  | ❌       | Small image to be displayed next to posts from account. AKA, 'profile picture' |                                    |
+| `banner`      | `union`  | ❌       | Larger horizontal image to display behind profile view.                        |                                    |
+| `createdAt`   | `string` | ❌       |                                                                                |                                    |
+
+---
+
 ## Type Definitions
 
 Common type definitions used across all protocols.

--- a/lexicons/app/certified/profile.json
+++ b/lexicons/app/certified/profile.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "app.certified.profile",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A declaration of a Hypercert account profile.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "maxGraphemes": 64,
+            "maxLength": 640
+          },
+          "description": {
+            "type": "string",
+            "description": "Free-form profile description text.",
+            "maxGraphemes": 256,
+            "maxLength": 2560
+          },
+          "pronouns": {
+            "type": "string",
+            "description": "Free-form pronouns text.",
+            "maxGraphemes": 20,
+            "maxLength": 200
+          },
+          "website": { "type": "string", "format": "uri" },
+          "avatar": {
+            "type": "union",
+            "refs": [
+              "org.hypercerts.defs#uri",
+              "org.hypercerts.defs#smallImage"
+            ],
+            "description": "Small image to be displayed next to posts from account. AKA, 'profile picture'"
+          },
+          "banner": {
+            "type": "union",
+            "refs": [
+              "org.hypercerts.defs#uri",
+              "org.hypercerts.defs#largeImage"
+            ],
+            "description": "Larger horizontal image to display behind profile view."
+          },
+          "createdAt": { "type": "string", "format": "datetime" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add profile lexicon for Hypercert account profiles with support for display name, description, pronouns, website, avatar, banner, and self-labels.

## Note

This profile lexicon is adapted from [Bluesky's actor.profile](https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/actor/profile.json) with some fields removed that aren't relevant to hypercerts profiles.

_Edit by Sharfy: The removed fields are `joinedViaStarterPack` and `pinnedPost`_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hypercert account profile support with customizable fields for display name, description, pronouns, website, avatar, and banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->