### PR TITLE
Move profile lexicon to app.certified.actor namespace

### DIFF
--- a/.changeset/move-profile-to-actor-namespace.md
+++ b/.changeset/move-profile-to-actor-namespace.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Move profile lexicon from app.certified.profile to app.certified.actor.profile namespace, requiring migration of existing profile records

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -356,21 +356,7 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 
 ---
 
-### `app.certified.defs`
-
-**Description:** Common type definitions used across certified protocols.
-
-#### Defs
-
-##### `app.certified.defs#did`
-
-| Property | Type     | Required | Description           |
-| -------- | -------- | -------- | --------------------- |
-| `did`    | `string` | ✅       | The DID string value. |
-
----
-
-### `app.certified.profile`
+### `app.certified.actor.profile`
 
 **Description:** A declaration of a Hypercert account profile.
 
@@ -387,6 +373,20 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 | `avatar`      | `union`  | ❌       | Small image to be displayed next to posts from account. AKA, 'profile picture' |                                    |
 | `banner`      | `union`  | ❌       | Larger horizontal image to display behind profile view.                        |                                    |
 | `createdAt`   | `string` | ❌       |                                                                                |                                    |
+
+---
+
+### `app.certified.defs`
+
+**Description:** Common type definitions used across certified protocols.
+
+#### Defs
+
+##### `app.certified.defs#did`
+
+| Property | Type     | Required | Description           |
+| -------- | -------- | -------- | --------------------- |
+| `did`    | `string` | ✅       | The DID string value. |
 
 ---
 

--- a/lexicons/app/certified/actor/profile.json
+++ b/lexicons/app/certified/actor/profile.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "app.certified.profile",
+  "id": "app.certified.actor.profile",
   "defs": {
     "main": {
       "type": "record",


### PR DESCRIPTION
## Summary
- Move profile lexicon from `app.certified.profile` to `app.certified.actor.profile` namespace

## Changes
- **Breaking**: Profile lexicon ID changed from `app.certified.profile` to `app.certified.actor.profile`
- Relocated lexicon file to `lexicons/app/certified/actor/profile.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Schema Updates**
  * Profile definitions have been reorganized and relocated to a new namespace structure within the certified lexicon system.
  * Profile schema definitions have been updated with new and refined properties and field constraints.
  * Lexicon configurations have been updated to reflect the new profile namespace structure throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->