### PR TITLE
feat: add org.hypercerts.claim.projectMetadata lexicon

### DIFF
--- a/.changeset/add-project-metadata-lexicon.md
+++ b/.changeset/add-project-metadata-lexicon.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add org.hypercerts.claim.projectMetadata lexicon as a sidecar record for project collections, providing tags, timeline, video, URLs, and context fields

--- a/ERD.puml
+++ b/ERD.puml
@@ -200,6 +200,19 @@ dataclass collection {
     !endif
 }
 
+' org.hypercerts.claim.projectMetadata (sidecar for collection)
+dataclass projectMetadata {
+    !if (SHOW_FIELDS == "true")
+    tags[]?
+    startDate?
+    endDate?
+    videoUrl?
+    urls[]?
+    context?
+    createdAt
+    !endif
+}
+
 ' org.hypercerts.acknowledgement
 dataclass acknowledgement {
     !if (SHOW_FIELDS == "true")
@@ -306,6 +319,8 @@ measurement --> location
 collection::items --> activity
 collection::items --> collection : "recursive\nnesting"
 collection::location --> location
+
+projectMetadata --> collection : "sidecar\n(same TID)"
 
 acknowledgement::subject --> activity
 acknowledgement::subject --> contributorInformation

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -226,6 +226,26 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 ---
 
+### `org.hypercerts.claim.projectMetadata`
+
+**Description:** Extended metadata sidecar for a project collection. Created with the same TID as its parent collection to link them together, allowing metadata updates without changing the collection's CID.
+
+**Key:** `tid`
+
+#### Properties
+
+| Property    | Type     | Required | Description                                                                           | Comments                             |
+| ----------- | -------- | -------- | ------------------------------------------------------------------------------------- | ------------------------------------ |
+| `tags`      | `string` | ❌       | Categorization tags for project discoverability.                                      | maxLength: 50                        |
+| `startDate` | `string` | ❌       | When the project is planned to start or started.                                      |                                      |
+| `endDate`   | `string` | ❌       | When the project is planned to end or ended.                                          |                                      |
+| `videoUrl`  | `string` | ❌       | URL to a project overview or impact video (YouTube, Vimeo, etc.).                     | maxLength: 10000, maxGraphemes: 2048 |
+| `urls`      | `string` | ❌       | Additional reference URLs related to the project (websites, reports, datasets, etc.). | maxLength: 20                        |
+| `context`   | `string` | ❌       | Free-form additional context about the project.                                       | maxLength: 50000, maxGraphemes: 5000 |
+| `createdAt` | `string` | ✅       | Client-declared timestamp when this record was originally created.                    |                                      |
+
+---
+
 ### `org.hypercerts.claim.rights`
 
 **Description:** Describes the rights that a contributor and/or an owner has, such as whether the hypercert can be sold, transferred, and under what conditions.

--- a/lexicons/org/hypercerts/claim/projectMetadata.json
+++ b/lexicons/org/hypercerts/claim/projectMetadata.json
@@ -1,0 +1,62 @@
+{
+  "lexicon": 1,
+  "id": "org.hypercerts.claim.projectMetadata",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Extended metadata sidecar for a project collection. Created with the same TID as its parent collection to link them together, allowing metadata updates without changing the collection's CID.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["createdAt"],
+        "properties": {
+          "tags": {
+            "type": "array",
+            "description": "Categorization tags for project discoverability.",
+            "items": { "type": "string", "maxLength": 640, "maxGraphemes": 64 },
+            "maxLength": 50
+          },
+          "startDate": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the project is planned to start or started."
+          },
+          "endDate": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the project is planned to end or ended."
+          },
+          "videoUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 10000,
+            "maxGraphemes": 2048,
+            "description": "URL to a project overview or impact video (YouTube, Vimeo, etc.)."
+          },
+          "urls": {
+            "type": "array",
+            "description": "Additional reference URLs related to the project (websites, reports, datasets, etc.).",
+            "items": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 10000,
+              "maxGraphemes": 2048
+            },
+            "maxLength": 20
+          },
+          "context": {
+            "type": "string",
+            "maxLength": 50000,
+            "maxGraphemes": 5000,
+            "description": "Free-form additional context about the project."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `org.hypercerts.claim.projectMetadata` lexicon as a sidecar record for project collections
- Adds projectMetadata entity and relationship to ERD.puml
- Regenerates SCHEMAS.md

## Design

This record uses the **same-TID sidecar pattern** established by `app.certified.location` — it shares the same TID as its parent `org.hypercerts.claim.collection`, linking them without a strongRef and allowing metadata updates without changing the collection's CID.

### Fields

| Field | Type | Description |
|---|---|---|
| `tags` | string[] (max 50) | Categorization tags for discoverability |
| `startDate` | datetime | When the project starts/started |
| `endDate` | datetime | When the project ends/ended |
| `videoUrl` | uri | Project overview or impact video URL |
| `urls` | uri[] (max 20) | Additional reference URLs |
| `context` | string (5000 graphemes) | Free-form additional project context |
| `createdAt` | datetime | Required timestamp |

All fields except `createdAt` are optional — consumers use only what they need.

### What's NOT included (by design)

- **No `description` field**: The parent collection already provides `shortDescription` (300 graphemes) and `description` (Leaflet rich doc)
- **No `avatar`/`banner`**: Already on the collection record
- **No `location`**: Already available as a separate sidecar via `app.certified.location`

## MaEarth adoption path

This schema directly replaces `MaEarthProjectMetadata`:

| MaEarth field | projectMetadata field | Notes |
|---|---|---|
| `categories` | `tags` | Direct match |
| `timeline.start` | `startDate` | Promoted to top-level field |
| `timeline.end` | `endDate` | Promoted to top-level field |
| `videoUrl` | `videoUrl` | Direct match |
| `additionalUrls` | `urls` | Direct match |
| `additionalContext` | `context` | Direct match |
| `description` | — | Use collection's `shortDescription` + Leaflet `description` instead |
| `createdAt` | `createdAt` | Direct match |

## Test plan

- [x] `npm run check` passes (gen-api, lint, typecheck, build, test)
- [x] Style checker: only datetime maxLength warnings (same as all other lexicons)
- [ ] Review schema design and field constraints
- [ ] Validate MaEarth adoption mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced project metadata sidecar for collections, enabling tags, timeline information (start/end dates), video links, URLs, and contextual information to be tracked independently.
  * Enhanced rights definition with expanded fields for name, type, description, attachments, and creation timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->