### PR TITLE
feat: add optional url field to badge award

### DIFF
--- a/.changeset/badge-award-url.md
+++ b/.changeset/badge-award-url.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add optional `url` field to `app.certified.badge.award` for linking to an external page associated with the badge

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -348,12 +348,13 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 
 #### Properties
 
-| Property    | Type     | Required | Description                                                                                                                                     | Comments       |
-| ----------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `badge`     | `ref`    | ✅       | Reference to the badge definition for this award.                                                                                               |                |
-| `subject`   | `union`  | ✅       | Entity the badge award is for (either an account DID or any specific AT Protocol record), e.g. a user, a project, or a specific activity claim. |                |
-| `note`      | `string` | ❌       | Optional statement explaining the reason for this badge award.                                                                                  | maxLength: 500 |
-| `createdAt` | `string` | ✅       | Client-declared timestamp when this record was originally created                                                                               |                |
+| Property    | Type     | Required | Description                                                                                                                                     | Comments        |
+| ----------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `badge`     | `ref`    | ✅       | Reference to the badge definition for this award.                                                                                               |                 |
+| `subject`   | `union`  | ✅       | Entity the badge award is for (either an account DID or any specific AT Protocol record), e.g. a user, a project, or a specific activity claim. |                 |
+| `note`      | `string` | ❌       | Optional statement explaining the reason for this badge award.                                                                                  | maxLength: 500  |
+| `url`       | `string` | ❌       | Optional URL the badge award links to.                                                                                                          | maxLength: 2048 |
+| `createdAt` | `string` | ✅       | Client-declared timestamp when this record was originally created                                                                               |                 |
 
 ---
 

--- a/lexicons/app/certified/badge/award.json
+++ b/lexicons/app/certified/badge/award.json
@@ -25,6 +25,12 @@
             "description": "Optional statement explaining the reason for this badge award.",
             "maxLength": 500
           },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Optional URL the badge award links to.",
+            "maxLength": 2048
+          },
           "createdAt": {
             "type": "string",
             "format": "datetime",


### PR DESCRIPTION
## Summary
- Adds an optional `url` field (`string`, `format: uri`, `maxLength: 2048`) to `app.certified.badge.award`
- Allows badge awards to link to an external page

## Test plan
- [x] `npm run check` passes (gen-api, lint, typecheck, build, tests)
- [x] SCHEMAS.md regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Badge awards now support an optional URL field, allowing users to link each award to external pages or resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->