### PR TITLE
fix: require createdAt in actor profile

### DIFF
--- a/.changeset/require-createdAt-in-profile.md
+++ b/.changeset/require-createdAt-in-profile.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Require createdAt in app.certified.actor.profile schema

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -376,7 +376,7 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 
 ### `app.certified.actor.profile`
 
-**Description:** A declaration of a Hypercert account profile.
+**Description:** A declaration of a Certified account profile.
 
 **Key:** `literal:self`
 
@@ -390,7 +390,7 @@ Certified lexicons are common/shared lexicons that can be used across multiple p
 | `website`     | `string` | ❌       | Account website URL                                                            |                                    |
 | `avatar`      | `union`  | ❌       | Small image to be displayed next to posts from account. AKA, 'profile picture' |                                    |
 | `banner`      | `union`  | ❌       | Larger horizontal image to display behind profile view.                        |                                    |
-| `createdAt`   | `string` | ❌       | Client-declared timestamp when this record was originally created              |                                    |
+| `createdAt`   | `string` | ✅       | Client-declared timestamp when this record was originally created              |                                    |
 
 ---
 

--- a/lexicons/app/certified/actor/profile.json
+++ b/lexicons/app/certified/actor/profile.json
@@ -4,10 +4,11 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A declaration of a Hypercert account profile.",
+      "description": "A declaration of a Certified account profile.",
       "key": "literal:self",
       "record": {
         "type": "object",
+        "required": ["createdAt"],
         "properties": {
           "displayName": {
             "type": "string",


### PR DESCRIPTION
## Summary
- Mark `createdAt` as a required field in `app.certified.actor.profile`
- Fix profile description to say "Certified" instead of "Hypercert"

## Test plan
- [x] `npm run check` passes (gen-api, lint, typecheck, build, test)
- [x] SCHEMAS.md regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated certified account profile specification wording.
  * The profile timestamp (createdAt) is now required for all certified profiles.

* **Chores**
  * Added a changeset noting the schema change and a minor package version bump.
  * Extended formatting ignore rules to include additional tooling paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->