### PR TITLE
feat: make acknowledgement context a union of URI and strongRef

### DIFF
--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -152,13 +152,13 @@ Hypercerts-specific lexicons for tracking impact work and claims.
 
 #### Properties
 
-| Property       | Type      | Required | Description                                                                                                                   | Comments                             |
-| -------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `subject`      | `ref`     | ✅       | The record being acknowledged (e.g. an activity, a contributor information record, an evaluation).                            |                                      |
-| `context`      | `ref`     | ❌       | Context for the acknowledgement (e.g. the collection that includes an activity, or the activity that includes a contributor). |                                      |
-| `acknowledged` | `boolean` | ✅       | Whether the relationship is acknowledged (true) or rejected (false).                                                          |                                      |
-| `comment`      | `string`  | ❌       | Optional plain-text comment providing additional context or reasoning.                                                        | maxLength: 10000, maxGraphemes: 1000 |
-| `createdAt`    | `string`  | ✅       | Client-declared timestamp when this record was originally created.                                                            |                                      |
+| Property       | Type      | Required | Description                                                                                                                                                                                                          | Comments                             |
+| -------------- | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `subject`      | `ref`     | ✅       | The record being acknowledged (e.g. an activity, a contributor information record, an evaluation).                                                                                                                   |                                      |
+| `context`      | `union`   | ❌       | Context for the acknowledgement (e.g. the collection that includes an activity, or the activity that includes a contributor). A URI for a lightweight reference or a strong reference for content-hash verification. |                                      |
+| `acknowledged` | `boolean` | ✅       | Whether the relationship is acknowledged (true) or rejected (false).                                                                                                                                                 |                                      |
+| `comment`      | `string`  | ❌       | Optional plain-text comment providing additional context or reasoning.                                                                                                                                               | maxLength: 10000, maxGraphemes: 1000 |
+| `createdAt`    | `string`  | ✅       | Client-declared timestamp when this record was originally created.                                                                                                                                                   |                                      |
 
 ---
 

--- a/lexicons/org/hypercerts/context/acknowledgement.json
+++ b/lexicons/org/hypercerts/context/acknowledgement.json
@@ -16,9 +16,9 @@
             "description": "The record being acknowledged (e.g. an activity, a contributor information record, an evaluation)."
           },
           "context": {
-            "type": "ref",
-            "ref": "com.atproto.repo.strongRef",
-            "description": "Context for the acknowledgement (e.g. the collection that includes an activity, or the activity that includes a contributor)."
+            "type": "union",
+            "refs": ["org.hypercerts.defs#uri", "com.atproto.repo.strongRef"],
+            "description": "Context for the acknowledgement (e.g. the collection that includes an activity, or the activity that includes a contributor). A URI for a lightweight reference or a strong reference for content-hash verification."
           },
           "acknowledged": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
- Changes the `context` field in `org.hypercerts.context.acknowledgement` from a plain `strongRef` to a union of `org.hypercerts.defs#uri` and `com.atproto.repo.strongRef`
- Allows consumers to use either a lightweight URI (including AT-URIs) or a content-hash-pinned strong reference for the acknowledgement context

## Test plan
- [x] All existing tests pass (`npm run check`)
- [x] SCHEMAS.md regenerated
- [x] Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Acknowledgement context now supports both lightweight URI and content-hash verified references for greater flexibility in reference types.

* **Documentation**
  * Updated schema documentation to reflect expanded reference capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->