### PR TITLE
docs: clarify main-only branch strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,10 @@ Use the `writing-changesets` skill. **DO NOT skip this step!**
 ## Branch Strategy
 
 **`main` is the only long-lived branch** and the default branch on GitHub.
-All pull requests must target `main`. There is no `develop` branch.
+All pull requests must target `main`.
 
 - `feature/*` — short-lived branches for development work, merged to `main` via PR
-- `prerelease/*` — ephemeral branches for beta releases only (see `docs/PUBLISHING.md`)
+- `prerelease/*` — ephemeral branches for beta releases only (see [docs/PUBLISHING.md](docs/PUBLISHING.md))
 
 > **Do not open PRs against `develop`** — it is a stale branch left over from
 > a previous workflow and is no longer used.

--- a/README.md
+++ b/README.md
@@ -371,8 +371,9 @@ const attachment = {
 ## Contributing
 
 `main` is the only long-lived branch and the default branch on GitHub.
-Open all pull requests against `main`. There is no `develop` branch —
-it is a stale leftover from a previous workflow and is no longer used.
+Open all pull requests against `main`. If you see a `develop` branch,
+it is a stale leftover from a previous workflow and is no longer used;
+do not open pull requests against it.
 
 See [docs/PUBLISHING.md](docs/PUBLISHING.md) for the full release workflow.
 


### PR DESCRIPTION
## Summary

- Adds a **Branch Strategy** section to `AGENTS.md` making it explicit that `main` is the only long-lived branch, all PRs must target `main`, and `develop` is stale and should not be used
- Adds a **Contributing** section to `README.md` with the same message and a link to `docs/PUBLISHING.md`

`main` is already the default branch on GitHub. This just makes the policy explicit in the docs that agents and contributors read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified branch strategy: "main" is the sole long-lived branch and all pull requests should target it.
  * Introduced short-lived feature/* branches for development and ephemeral prerelease/* branches for beta releases.
  * Added explicit instruction not to open pull requests against "develop".
  * Linked to the release/publishing workflow for full details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->