### PR TITLE
fix: remove erroneous git add from schemas merge driver

### DIFF
--- a/scripts/setup-merge-driver.sh
+++ b/scripts/setup-merge-driver.sh
@@ -4,6 +4,6 @@
 # When SCHEMAS.md has conflicts, it will be regenerated from lexicon files.
 # This script should be auto-run on npm install via the "prepare" script.
 
-git config --local merge.schemas.driver "npm run gen-schemas-md --silent && cp SCHEMAS.md %A"
+git config --local merge.schemas.driver "npm run gen-schemas-md --silent && cp -- SCHEMAS.md \"%A\""
 
 echo "✅ Configured merge driver for SCHEMAS.md"


### PR DESCRIPTION
## Summary

The `schemas` merge driver in `scripts/setup-merge-driver.sh` was calling `git add -u -- %A` after regenerating `SCHEMAS.md`. This is wrong for two reasons:

1. **Git holds the index lock during a merge/rebase** — any inner `git add` call fails immediately with `Unable to create .git/index.lock: File exists`, breaking the merge.
2. **Merge drivers don't stage files** — they just write resolved content to `%A` (the temp file git provides) and exit 0. Git handles staging from there.

The fix replaces `git add -u -- %A` with `cp SCHEMAS.md %A`, which correctly delivers the regenerated content to git without touching the index.

## Why wasn't this caught sooner?

The driver only runs when `SCHEMAS.md` actually conflicts during a merge/rebase. When it does conflict, the `git add` fails and leaves the rebase in a broken state with a stale `index.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Git merge driver configuration for SCHEMAS.md with more efficient conflict resolution and reduced console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->