### PR TITLE
ci(release): include version number in Release PR title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,11 +104,32 @@ jobs:
         with:
           publish: npm run release
           version: npm run version-packages
-          title: "chore: release package"
-          commit: "chore: release package"
+          title: "Release"
+          commit: "Release"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
+
+      # changesets/action does not support templating the version into the
+      # PR title (see changesets/action#388). As a workaround, rename the
+      # Release PR to include the version number after the action has run
+      # the version bump. The commit message on the release branch is left
+      # as the static "Release" value — it gets rewritten on every re-run
+      # of this workflow, and the merge commit title on main is controlled
+      # by the person merging the PR.
+      - name: Rename Release PR with version
+        if: env.RELEASE_TYPE == 'stable' && steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          VERSION=$(gh api \
+            "repos/${{ github.repository }}/contents/package.json?ref=changeset-release/main" \
+            -H "Accept: application/vnd.github.raw" \
+            | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          NEW_TITLE="Release v$VERSION"
+          echo "Renaming PR #$PR_NUMBER to: $NEW_TITLE"
+          gh pr edit "$PR_NUMBER" --title "$NEW_TITLE"
 
       # Beta release: version, commit, publish, and push in one step.
       # changesets/action is not used here because it requires two workflow


### PR DESCRIPTION
## Summary

- Rename the changesets Release PR to \`Release v<version>\` after \`changesets/action\` runs, by reading \`package.json\` from the \`changeset-release/main\` branch and calling \`gh pr edit\`.
- Drop the \`chore:\` prefix from the static \`title\` / \`commit\` inputs.

## Why

\`changesets/action\` does not support templating the version into the Release PR title or commit message — it accepts only a static string, and the default (\`Version Packages\`) also lacks the version. This is a long-standing upstream gap tracked in [changesets/action#388](https://github.com/changesets/action/issues/388) (open since Aug 2024), with related issues #303 and #353. The workaround used here — renaming the PR after the fact — is what several commenters on those issues report doing.

## Notes

- Only the **PR title** is rewritten. The branch commit message stays as the static \`Release\` value; it gets rewritten on every re-run of the workflow anyway, and the merge commit title on \`main\` is controlled by whoever merges.
- The step is gated on \`RELEASE_TYPE == 'stable'\` and only runs when \`changesets/action\` actually opened or updated a PR (\`pullRequestNumber\` output is non-empty). On the publish run (when there are no pending changesets) it's a no-op.
- The beta release path is untouched — it publishes directly without a PR, so there's nothing to rename.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger the \`Release\` workflow manually on \`main\`. Confirm the existing Release PR is renamed to \`Release v<version>\`.
- [ ] Confirm a subsequent re-run (after an additional changeset lands) still renames correctly with the new version.
- [ ] Confirm the publish run (after merging the Release PR) does not error on the rename step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process automation with improved release PR identification and naming conventions for better tracking of stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->