### PR TITLE
fix: sync vendored pub.leaflet.blocks.image with upstream

### DIFF
--- a/.changeset/sync-leaflet-image-upstream.md
+++ b/.changeset/sync-leaflet-image-upstream.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": patch
+---
+
+Sync vendored `pub.leaflet.blocks.image` lexicon with upstream, adding the optional `fullBleed` boolean property

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -801,11 +801,12 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 
 #### Properties
 
-| Property      | Type     | Required | Description                                           | Comments                             |
-| ------------- | -------- | -------- | ----------------------------------------------------- | ------------------------------------ |
-| `image`       | `blob`   | ✅       |                                                       | maxSize: 1000000, accepts: `image/*` |
-| `alt`         | `string` | ❌       | Alt text description of the image, for accessibility. |                                      |
-| `aspectRatio` | `ref`    | ✅       |                                                       |                                      |
+| Property      | Type      | Required | Description                                                                           | Comments                             |
+| ------------- | --------- | -------- | ------------------------------------------------------------------------------------- | ------------------------------------ |
+| `image`       | `blob`    | ✅       |                                                                                       | maxSize: 1000000, accepts: `image/*` |
+| `alt`         | `string`  | ❌       | Alt text description of the image, for accessibility.                                 |                                      |
+| `aspectRatio` | `ref`     | ✅       |                                                                                       |                                      |
+| `fullBleed`   | `boolean` | ❌       | Whether the image should extend to the full width of the container, ignoring padding. |                                      |
 
 #### Defs
 

--- a/lexicons/pub/leaflet/blocks/image.json
+++ b/lexicons/pub/leaflet/blocks/image.json
@@ -18,6 +18,10 @@
         "aspectRatio": {
           "type": "ref",
           "ref": "#aspectRatio"
+        },
+        "fullBleed": {
+          "type": "boolean",
+          "description": "Whether the image should extend to the full width of the container, ignoring padding."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Syncs the vendored `pub.leaflet.blocks.image` lexicon with the version published on ATProto
- Adds the optional `fullBleed` boolean property (`"Whether the image should extend to the full width of the container, ignoring padding."`)
- Detected via `goat lex status` which showed the local copy was behind upstream

This is a non-breaking addition (new optional field on a vendored external lexicon).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image blocks now support an optional `fullBleed` property to extend images to the full container width, ignoring padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->