### PR TITLE
chore(changeset): promote to v1.0.0 stable

### DIFF
--- a/.changeset/promote-to-v1-stable.md
+++ b/.changeset/promote-to-v1-stable.md
@@ -4,8 +4,16 @@
 
 Promote `@hypercerts-org/lexicon` to v1.0.0 — first stable release.
 
-No schema changes from v0.13.0. This release marks the lexicons,
-TypeScript types, and generated exports as stable for downstream
-consumers and shifts the package onto standard SemVer semantics (where
-future breaking changes will bump the major version, non-breaking
-additions the minor version, and fixes the patch version).
+This changeset contributes no schema or type changes of its own; it
+exists solely to force a major version bump so the package crosses the
+0.x → 1.0 line. From v1.0.0 onward, the lexicons, TypeScript types,
+and generated exports are considered stable for downstream consumers,
+and the package follows standard SemVer semantics: breaking changes
+bump the major version, non-breaking additions the minor version, and
+fixes the patch version. (Prior to v1.0.0, breaking changes were
+allowed under `minor` per the SemVer 0.x convention — see
+`.claude/skills/writing-changesets/SKILL.md`.)
+
+Any other changesets pending at the time this one is consumed are
+folded into the same v1.0.0 release; see the other entries below for
+those contributions.

--- a/.changeset/promote-to-v1-stable.md
+++ b/.changeset/promote-to-v1-stable.md
@@ -1,0 +1,11 @@
+---
+"@hypercerts-org/lexicon": major
+---
+
+Promote `@hypercerts-org/lexicon` to v1.0.0 — first stable release.
+
+No schema changes from v0.13.0. This release marks the lexicons,
+TypeScript types, and generated exports as stable for downstream
+consumers and shifts the package onto standard SemVer semantics (where
+future breaking changes will bump the major version, non-breaking
+additions the minor version, and fixes the patch version).


### PR DESCRIPTION
## What

Adds a single `major` changeset file (`.changeset/promote-to-v1-stable.md`) so the next changesets Release PR bumps the package from `0.13.0` → `1.0.0`.

That's the entire diff of this PR vs `main`:

```
$ git diff origin/main...HEAD --stat
 .changeset/promote-to-v1-stable.md | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)
```

No schema edits, no generated-code edits, no API edits. This PR is purely a version-bump signal for changesets.

## Why

Marks the lexicons, TypeScript types, and generated exports as stable for downstream consumers and shifts the package onto standard SemVer semantics (future breaking changes → major, non-breaking additions → minor, fixes → patch).

## What the eventual v1.0.0 release will contain

The release is _not_ just this changeset. When `release.yml` consumes the pending `.changeset/*.md` files, it will combine **every** unconsumed changeset on `main` at that moment into one release. As of now that means:

| Changeset | Bump | Source | Effect on `1.0.0` |
|---|---|---|---|
| `promote-to-v1-stable.md` | `major` | this PR | forces `0.13.0` → `1.0.0` |
| `increase-workscope-string-limit.md` | `minor` | already on `main` via #212 | raises `org.hypercerts.claim.activity` work scope string from 100 → 1,000 graphemes (10,000-byte cap) |

The `major` bump wins for version determination, so the final version is `1.0.0` (not `0.14.0` from the `minor`). Both changeset bodies will appear under the `## 1.0.0` heading in `CHANGELOG.md`.

If any further changesets land on `main` before the release workflow is run, they'll also be folded into `1.0.0` automatically.

## Verification

```
$ npx changeset status --verbose
🦋  info Packages to be bumped at major
🦋  - @hypercerts-org/lexicon 1.0.0
🦋    - .changeset/increase-workscope-string-limit.md
🦋    - .changeset/promote-to-v1-stable.md
```

Local `npm run check` (lint + typecheck + build + 147 tests) passes.

## Release flow from here

1. Merge this PR
2. Manually run `release.yml` on `main` → opens a "Release v1.0.0" PR (bumps `package.json`, updates CHANGELOG)
3. Merge that PR
4. Manually run `release.yml` on `main` again → publishes `1.0.0` to npm + tags `v1.0.0`

See `docs/PUBLISHING.md` for the full workflow.