### PR TITLE
Fix SCHEMAS merge driver rebase side effect

### DIFF
--- a/scripts/generate-schemas.js
+++ b/scripts/generate-schemas.js
@@ -5,13 +5,45 @@
  */
 
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, dirname, relative } from "node:path";
+import { join, dirname, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import stringWidth from "string-width";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, "..");
 const lexiconsDir = join(projectRoot, "lexicons");
+const defaultOutputPath = join(projectRoot, "SCHEMAS.md");
+
+function resolveOutputPath(path) {
+  return isAbsolute(path) ? path : join(projectRoot, path);
+}
+
+function parseOutputPath(argv) {
+  let outputPath = defaultOutputPath;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "--outfile" || arg === "-o") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a path`);
+      }
+      outputPath = resolveOutputPath(value);
+      i++;
+    } else if (arg.startsWith("--outfile=")) {
+      const value = arg.slice("--outfile=".length);
+      if (!value) {
+        throw new Error("--outfile requires a path");
+      }
+      outputPath = resolveOutputPath(value);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return outputPath;
+}
 
 // File system utilities
 function findJsonFiles(dir, baseDir = dir) {
@@ -33,7 +65,13 @@ function findJsonFiles(dir, baseDir = dir) {
 function readLexicon(filePath) {
   const fullPath = join(lexiconsDir, filePath);
   const content = readFileSync(fullPath, "utf-8");
-  return JSON.parse(content);
+
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse lexicon ${filePath}: ${message}`);
+  }
 }
 
 // Type and metadata extraction
@@ -431,8 +469,8 @@ function generateMarkdown() {
 
 async function main() {
   try {
+    const outputPath = parseOutputPath(process.argv.slice(2));
     const content = generateMarkdown();
-    const outputPath = join(projectRoot, "SCHEMAS.md");
     writeFileSync(outputPath, content, "utf-8");
     console.log(`✅ Generated ${outputPath}`);
   } catch (error) {

--- a/scripts/setup-merge-driver.sh
+++ b/scripts/setup-merge-driver.sh
@@ -2,8 +2,10 @@
 # Configure git merge driver for SCHEMAS.md
 #
 # When SCHEMAS.md has conflicts, it will be regenerated from lexicon files.
+# The driver must write only to Git's %A merge-file path. Generating
+# ./SCHEMAS.md as a worktree side effect leaves rebases dirty between steps.
 # This script should be auto-run on npm install via the "prepare" script.
 
-git config --local merge.schemas.driver "npm run gen-schemas-md --silent && cp -- SCHEMAS.md \"%A\""
+git config --local merge.schemas.driver "npm run --silent gen-schemas-md -- --outfile \"%A\""
 
 echo "✅ Configured merge driver for SCHEMAS.md"


### PR DESCRIPTION
## Summary
- add an --outfile option to scripts/generate-schemas.js
- configure the SCHEMAS.md merge driver to write directly to Git's %A merge-file path
- keep default SCHEMAS.md generation behavior unchanged

Fixes #226

## Tests
- npm run check
- ubs scripts/generate-schemas.js scripts/setup-merge-driver.sh
- npm run --silent gen-schemas-md -- --outfile /tmp/hypercerts-schemas-226.md (verified SCHEMAS.md unchanged and output matches)
