### PR TITLE
[HYPER-502] add app.certified.actor.createdVia lexicon

### DIFF
--- a/.changeset/add-actor-created-via.md
+++ b/.changeset/add-actor-created-via.md
@@ -1,0 +1,9 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Add `app.certified.actor.createdVia` record lexicon for lightweight account provenance.
+
+The record carries a required `clientId` property holding the OAuth `client_id` URL (the client metadata document URL) that uniquely identifies the application which created the Certified account. This lets consumers distinguish records originating from, for example, test or staging environments from real ones, without requiring cryptographic platform attestations.
+
+Like other Certified records, it includes an optional `signatures` array (`app.certified.signature.defs#list`) so the provenance marker can itself be attested.

--- a/.changeset/add-actor-created-via.md
+++ b/.changeset/add-actor-created-via.md
@@ -4,6 +4,6 @@
 
 Add `app.certified.actor.createdVia` record lexicon for lightweight account provenance.
 
-The record carries a required `clientId` property holding the OAuth `client_id` URL (the client metadata document URL) that uniquely identifies the application which created the Certified account. This lets consumers distinguish records originating from, for example, test or staging environments from real ones, without requiring cryptographic platform attestations.
+The record carries an optional `clientId` property holding the OAuth `client_id` URL (the client metadata document URL) that uniquely identifies the application which created the Certified account. This lets consumers distinguish records originating from, for example, test or staging environments from real ones, without requiring cryptographic platform attestations.
 
 Like other Certified records, it includes an optional `signatures` array (`app.certified.signature.defs#list`) so the provenance marker can itself be attested.

--- a/ERD.puml
+++ b/ERD.puml
@@ -56,6 +56,14 @@ dataclass organization {
     !endif
 }
 
+' app.certified.actor.createdVia
+dataclass createdVia {
+    !if (SHOW_FIELDS == "true")
+    clientId
+    createdAt
+    !endif
+}
+
 ' Contributors are represented by DIDs or human-readable strings
 ' therefore do not require modelling via a lexicon.
 entity "contributor (DID/profile)" as contributorEntity #FFD4A3 {

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -431,6 +431,22 @@ A location represented as a string, e.g. coordinates or a small GeoJSON string.
 
 ---
 
+### `app.certified.actor.createdVia`
+
+**Description:** Records which application created this Certified account, identified by the OAuth client_id URL of that application. A lightweight provenance marker that lets consumers distinguish, for example, records originating from a test or staging environment from real ones, without requiring cryptographic platform attestations.
+
+**Key:** `literal:self`
+
+#### Properties
+
+| Property     | Type     | Required | Description                                                                                                                                                                                                                          |
+| ------------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `clientId`   | `string` | ✅       | The OAuth `client_id` URL uniquely identifying the application that created this account. This is the client metadata document URL used during the ATProto OAuth flow (e.g. 'https://app.certified.one/oauth/client-metadata.json'). |
+| `createdAt`  | `string` | ✅       | Client-declared timestamp when this record was originally created.                                                                                                                                                                   |
+| `signatures` | `ref`    | ❌       | Optional cryptographic signatures attesting to this record's content.                                                                                                                                                                |
+
+---
+
 ### `app.certified.actor.organization`
 
 **Description:** Extended metadata for an organization actor. Complements the base actor profile with organization-specific fields like legal structure and reference links.

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -441,7 +441,7 @@ A location represented as a string, e.g. coordinates or a small GeoJSON string.
 
 | Property     | Type     | Required | Description                                                                                                                                                                                                                          |
 | ------------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `clientId`   | `string` | ✅       | The OAuth `client_id` URL uniquely identifying the application that created this account. This is the client metadata document URL used during the ATProto OAuth flow (e.g. 'https://app.certified.one/oauth/client-metadata.json'). |
+| `clientId`   | `string` | ❌       | The OAuth `client_id` URL uniquely identifying the application that created this account. This is the client metadata document URL used during the ATProto OAuth flow (e.g. 'https://app.certified.one/oauth/client-metadata.json'). |
 | `createdAt`  | `string` | ✅       | Client-declared timestamp when this record was originally created.                                                                                                                                                                   |
 | `signatures` | `ref`    | ❌       | Optional cryptographic signatures attesting to this record's content.                                                                                                                                                                |
 

--- a/lexicons/app/certified/actor/createdVia.json
+++ b/lexicons/app/certified/actor/createdVia.json
@@ -1,0 +1,32 @@
+{
+  "lexicon": 1,
+  "id": "app.certified.actor.createdVia",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Records which application created this Certified account, identified by the OAuth client_id URL of that application. A lightweight provenance marker that lets consumers distinguish, for example, records originating from a test or staging environment from real ones, without requiring cryptographic platform attestations.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["clientId", "createdAt"],
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "format": "uri",
+            "description": "The OAuth `client_id` URL uniquely identifying the application that created this account. This is the client metadata document URL used during the ATProto OAuth flow (e.g. 'https://app.certified.one/oauth/client-metadata.json')."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this record was originally created."
+          },
+          "signatures": {
+            "type": "ref",
+            "ref": "app.certified.signature.defs#list",
+            "description": "Optional cryptographic signatures attesting to this record's content."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/certified/actor/createdVia.json
+++ b/lexicons/app/certified/actor/createdVia.json
@@ -8,7 +8,7 @@
       "key": "literal:self",
       "record": {
         "type": "object",
-        "required": ["clientId", "createdAt"],
+        "required": ["createdAt"],
         "properties": {
           "clientId": {
             "type": "string",

--- a/tests/validate-actor-created-via.test.ts
+++ b/tests/validate-actor-created-via.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { validate, ids } from "../generated/lexicons.js";
+import * as CreatedVia from "../generated/types/app/certified/actor/createdVia.js";
+
+describe("app.certified.actor.createdVia", () => {
+  it("should accept a minimal valid record (required clientId and createdAt)", () => {
+    const result = CreatedVia.validateMain({
+      $type: ids.AppCertifiedActorCreatedVia,
+      clientId: "https://app.certified.one/oauth/client-metadata.json",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.clientId).toBe(
+        "https://app.certified.one/oauth/client-metadata.json",
+      );
+    }
+  });
+
+  it("should accept a record with inline signatures", () => {
+    const result = CreatedVia.validateMain({
+      $type: ids.AppCertifiedActorCreatedVia,
+      clientId: "https://app.certified.one/oauth/client-metadata.json",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      signatures: [
+        {
+          $type: "app.certified.signature.defs#inline",
+          signature: new Uint8Array([1, 2, 3]),
+          key: "did:plc:abc123#atproto",
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject a record missing required clientId", () => {
+    const result = validate(
+      { createdAt: "2024-01-01T00:00:00.000Z" },
+      ids.AppCertifiedActorCreatedVia,
+      "main",
+      false,
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeDefined();
+    }
+  });
+
+  it("should reject a record missing required createdAt", () => {
+    const result = validate(
+      { clientId: "https://app.certified.one/oauth/client-metadata.json" },
+      ids.AppCertifiedActorCreatedVia,
+      "main",
+      false,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject a record with a non-uri clientId", () => {
+    const result = validate(
+      {
+        clientId: "not a uri",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      },
+      ids.AppCertifiedActorCreatedVia,
+      "main",
+      false,
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject a record with an invalid createdAt format", () => {
+    const result = validate(
+      {
+        clientId: "https://app.certified.one/oauth/client-metadata.json",
+        createdAt: "not-a-datetime",
+      },
+      ids.AppCertifiedActorCreatedVia,
+      "main",
+      false,
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/validate-actor-created-via.test.ts
+++ b/tests/validate-actor-created-via.test.ts
@@ -3,7 +3,15 @@ import { validate, ids } from "../generated/lexicons.js";
 import * as CreatedVia from "../generated/types/app/certified/actor/createdVia.js";
 
 describe("app.certified.actor.createdVia", () => {
-  it("should accept a minimal valid record (required clientId and createdAt)", () => {
+  it("should accept a minimal valid record (only required createdAt)", () => {
+    const result = CreatedVia.validateMain({
+      $type: ids.AppCertifiedActorCreatedVia,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a record with optional clientId", () => {
     const result = CreatedVia.validateMain({
       $type: ids.AppCertifiedActorCreatedVia,
       clientId: "https://app.certified.one/oauth/client-metadata.json",
@@ -33,17 +41,14 @@ describe("app.certified.actor.createdVia", () => {
     expect(result.success).toBe(true);
   });
 
-  it("should reject a record missing required clientId", () => {
+  it("should accept a record missing optional clientId", () => {
     const result = validate(
       { createdAt: "2024-01-01T00:00:00.000Z" },
       ids.AppCertifiedActorCreatedVia,
       "main",
       false,
     );
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toBeDefined();
-    }
+    expect(result.success).toBe(true);
   });
 
   it("should reject a record missing required createdAt", () => {


### PR DESCRIPTION
## Summary

Adds a new lexicon **`app.certified.actor.createdVia`** — a lightweight account-provenance record identifying the application that created a Certified account via its OAuth `client_id` URL.

Refs [HYPER-502](https://linear.app/hypercerts/issue/HYPER-502/add-createdvia-sidecar-lexicon).

### Why

Lets consumers distinguish records originating from test/staging environments from real ones, without requiring full cryptographic platform attestations (a lighter-weight alternative to HYPER-181). The `signatures` array still allows the provenance marker itself to be attested when a stronger guarantee is wanted.

### Schema

- `key`: `literal:self` — one `createdVia` record per repo, mirroring `app.certified.actor.profile` / `.organization`.
- **`clientId`** (required, `uri`) — the OAuth `client_id` URL (client metadata document URL) uniquely identifying the creating app. Named `clientId` (camelCase) to satisfy the repo's `property-name-camelcase` style rule; the description records that it holds the OAuth `client_id` value.
- **`createdAt`** (required, `datetime`).
- **`signatures`** (optional) — `app.certified.signature.defs#list`, consistent with every other Certified record.

### Changeset

`minor` (non-breaking additive lexicon).

## Generated / regenerated

- `generated/` — via `npm run gen-api` (gitignored, not in diff).
- `SCHEMAS.md` — via `npm run gen-schemas-md`.
- `ERD.puml` — added a `createdVia` dataclass.

> ⚠️ **ERD images not regenerated.** `ERD.png` / `ERD.svg` are committed binaries with no repo render script and PlantUML isn't available in the dev environment here. They are now stale vs `ERD.puml` and should be re-rendered by someone with PlantUML.

## Open design question (draft)

Whether `clientId` should be **required** or **optional**. A signature signed by the client's service DID (`did:web`) can itself identify the origin, making `clientId` partly redundant; both-present enables a domain sanity check between the `client_id` URL and the `did:web` domain. See the discussion comment below. Pending a decision on the minimum-validity constraint.

## Test plan

- [x] `npm run check` — validate + typecheck + build, **188 tests pass**
- [x] `node scripts/check-lexicon-style.js` — 0 errors
- [x] New `tests/validate-actor-created-via.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Certified account provenance record, including creation time, optional application identifier, and optional signatures.
  * Updated schema documentation and diagrams to reflect the new record.

* **Tests**
  * Added validation coverage for valid records and common failure cases, including missing timestamps and invalid identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->