### PR TITLE
docs(agents): mark beads/bd tracking as a historical artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,91 +396,20 @@ See `ERD.puml` for the entity relationship diagram. Key relationships:
 
 <!-- BEGIN BEADS INTEGRATION -->
 
-## Issue Tracking with bd (beads)
+## Issue Tracking (historical: bd / beads)
 
-**IMPORTANT**: Developers of this project sometimes use **bd
-(beads)**, but _not_ for _all_ issue tracking. At the time of writing,
-the GitHub issue tracker is also used.
+**The `.beads/` directory and its bd (beads) database are a historical
+artifact.** They date from the repository's initial buildout, when bd
+was used for some issue tracking. That workflow is no longer in use.
 
-### Why bd?
+**Do not use bd / beads for task tracking in this repository.** Any
+`bd`-based guidance you may have picked up elsewhere does not apply
+here — the database is stale and may not even open. Use the **GitHub
+issue tracker** instead. If you need lightweight, in-session task
+tracking, use your own agent task tooling; do not resurrect bd.
 
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Dolt-powered version control with native sync
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update <id> --claim --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task atomically**: `bd update <id> --claim`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs via Dolt:
-
-- Each write auto-commits to Dolt history
-- Use `bd dolt push`/`bd dolt pull` for remote sync
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
+The `.beads/` files (and any bd git hooks under `.beads/hooks/`) are
+retained only for historical reference and are not maintained.
 
 <!-- END BEADS INTEGRATION -->
 
@@ -490,19 +419,18 @@ For more details, see README.md and docs/QUICKSTART.md.
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Open GitHub issues for anything
+   that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+3. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push origin HEAD
    git status  # MUST show "up to date with origin"
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+4. **Clean up** - Clear stashes, prune remote branches
+5. **Verify** - All changes committed AND pushed
+6. **Hand off** - Provide context for next session
 
 **CRITICAL RULES:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,7 +409,10 @@ issue tracker** instead. If you need lightweight, in-session task
 tracking, use your own agent task tooling; do not resurrect bd.
 
 The `.beads/` files (and any bd git hooks under `.beads/hooks/`) are
-retained only for historical reference and are not maintained.
+retained only for historical reference and are not maintained. The
+scripts under `.beads/hooks/` are inert: `npm run prepare` installs
+husky, which points `core.hooksPath` at `.husky/`, so git never
+executes anything under `.beads/hooks/`.
 
 <!-- END BEADS INTEGRATION -->
 


### PR DESCRIPTION
## Summary

`AGENTS.md` still carried a full **BEADS INTEGRATION** how-to block presenting bd (beads) as the live task-tracking system for this repo — "Use bd for ALL task tracking", "Do NOT use external issue trackers", command recipes, an auto-sync section, etc.

That is no longer true. beads was only used during the repository's **initial buildout**; the `.beads/` directory and its bd database are now a **historical artifact**. The database is stale and may not even open (it currently errors on `failed to initialize schema: pending schema migrations`). The old guidance therefore actively misleads AI agents into resurrecting a dead workflow.

## Changes

| | Before | After |
| --- | --- | --- |
| Beads section (~90 lines) | "Issue Tracking with bd (beads)" how-to: why bd, quick start, issue types, priorities, agent workflow, auto-sync, rules | Short "Issue Tracking (historical: bd / beads)" note: `.beads/` is retained-for-history-only; **do not use bd**; use the GitHub issue tracker |
| "Landing the Plane" step 3 | "Update issue status" (bd-flavoured) | removed |
| "Landing the Plane" push block | included `bd dolt push` | removed; git pull/push/verify flow kept |
| `docs/QUICKSTART.md` reference | linked (file does not exist) | dropped with the block |

The `<!-- BEGIN/END BEADS INTEGRATION -->` markers are kept as anchors. They are unrelated to bd's git-hook markers under `.beads/hooks/`, so this is a plain manual edit — bd tooling does not regenerate this block.

## Scope / non-changes

- **Docs-only**, `AGENTS.md` only. Not in the npm package `files`, not the downstream `SKILL.md`, so **no changeset** per the `writing-changesets` skill.
- `.beads/` files themselves are left in place (still git-tracked) — this PR only stops the docs from telling agents to use them.
- Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository task-tracking guidance to use GitHub issues instead of the legacy beads workflow.
  * Revised session-completion instructions for creating follow-up issues, syncing changes, pushing updates, and verifying repository status.
  * Clarified that historical task-tracking artifacts are inactive and should no longer be used for managing work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->