### PR TITLE
leaflet: sync published lexicon schemas

### DIFF
--- a/.changeset/update-leaflet-lexicons.md
+++ b/.changeset/update-leaflet-lexicons.md
@@ -1,0 +1,5 @@
+---
+"@hypercerts-org/lexicon": minor
+---
+
+Sync vendored Leaflet schemas with their published versions, adding eight block and theme schemas and making iframe URLs optional

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -757,10 +757,10 @@ Facet feature for a hashtag. The text usually includes a '#' prefix, but the fac
 
 Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.
 
-| Property    | Type      | Required | Description |
-| ----------- | --------- | -------- | ----------- |
-| `byteStart` | `integer` | ✅       |             |
-| `byteEnd`   | `integer` | ✅       |             |
+| Property    | Type      | Required | Description | Comments   |
+| ----------- | --------- | -------- | ----------- | ---------- |
+| `byteStart` | `integer` | ✅       |             | minimum: 0 |
+| `byteEnd`   | `integer` | ✅       |             | minimum: 0 |
 
 ---
 
@@ -817,7 +817,7 @@ Visual configuration for a hyperboard's background, colors, and layout.
 | `backgroundImage`     | `union`   | ❌       | Background image as a URI or image blob.                              |                                                   |
 | `backgroundIframeUrl` | `string`  | ❌       | URI of the background iframe.                                         | maxLength: 2048                                   |
 | `backgroundGrayscale` | `boolean` | ❌       | Whether the background is rendered in grayscale. Default: true.       |                                                   |
-| `backgroundOpacity`   | `integer` | ❌       | Background opacity as a percentage (0–100).                           |                                                   |
+| `backgroundOpacity`   | `integer` | ❌       | Background opacity as a percentage (0–100).                           | minimum: 0, maximum: 100                          |
 | `backgroundColor`     | `string`  | ❌       | Background color as a hex string (e.g. '#ffffff').                    | maxLength: 20                                     |
 | `borderColor`         | `string`  | ❌       | Border color as a hex string (e.g. '#000000').                        | maxLength: 20                                     |
 | `grayscaleImages`     | `boolean` | ❌       | Whether contributor images are rendered in grayscale. Default: false. |                                                   |
@@ -911,11 +911,11 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 
 #### Properties
 
-| Property    | Type      | Required | Description |
-| ----------- | --------- | -------- | ----------- |
-| `level`     | `integer` | ❌       |             |
-| `plaintext` | `string`  | ✅       |             |
-| `facets`    | `ref[]`   | ❌       |             |
+| Property    | Type      | Required | Description | Comments               |
+| ----------- | --------- | -------- | ----------- | ---------------------- |
+| `level`     | `integer` | ❌       |             | minimum: 1, maximum: 6 |
+| `plaintext` | `string`  | ✅       |             |                        |
+| `facets`    | `ref[]`   | ❌       |             |                        |
 
 ---
 
@@ -925,14 +925,46 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 
 ---
 
+### `pub.leaflet.blocks.html`
+
+#### Properties
+
+| Property      | Type      | Required | Description                                                     | Comments                   |
+| ------------- | --------- | -------- | --------------------------------------------------------------- | -------------------------- |
+| `html`        | `string`  | ✅       | Inline HTML rendered via a sandboxed iframe's srcdoc attribute. |                            |
+| `height`      | `integer` | ❌       |                                                                 | minimum: 16, maximum: 1600 |
+| `aspectRatio` | `ref`     | ❌       |                                                                 |                            |
+
+#### Defs
+
+##### `pub.leaflet.blocks.html#aspectRatio`
+
+| Property | Type      | Required | Description |
+| -------- | --------- | -------- | ----------- |
+| `width`  | `integer` | ✅       |             |
+| `height` | `integer` | ✅       |             |
+
+---
+
 ### `pub.leaflet.blocks.iframe`
 
 #### Properties
 
+| Property      | Type      | Required | Description                                                                                                                          | Comments                   |
+| ------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `url`         | `string`  | ❌       |                                                                                                                                      |                            |
+| `html`        | `string`  | ❌       | DEPRECATED — use pub.leaflet.blocks.html instead. Inline HTML rendered via the iframe's srcdoc attribute. Takes precedence over url. |                            |
+| `height`      | `integer` | ❌       |                                                                                                                                      | minimum: 16, maximum: 1600 |
+| `aspectRatio` | `ref`     | ❌       |                                                                                                                                      |                            |
+
+#### Defs
+
+##### `pub.leaflet.blocks.iframe#aspectRatio`
+
 | Property | Type      | Required | Description |
 | -------- | --------- | -------- | ----------- |
-| `url`    | `string`  | ✅       |             |
-| `height` | `integer` | ❌       |             |
+| `width`  | `integer` | ✅       |             |
+| `height` | `integer` | ✅       |             |
 
 ---
 
@@ -946,10 +978,41 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 | `alt`         | `string`  | ❌       | Alt text description of the image, for accessibility.                                 |                                      |
 | `aspectRatio` | `ref`     | ✅       |                                                                                       |                                      |
 | `fullBleed`   | `boolean` | ❌       | Whether the image should extend to the full width of the container, ignoring padding. |                                      |
+| `width`       | `integer` | ❌       | Display width of the image in pixels, capped at the page width.                       |                                      |
 
 #### Defs
 
 ##### `pub.leaflet.blocks.image#aspectRatio`
+
+| Property | Type      | Required | Description |
+| -------- | --------- | -------- | ----------- |
+| `width`  | `integer` | ✅       |             |
+| `height` | `integer` | ✅       |             |
+
+---
+
+### `pub.leaflet.blocks.imageGallery`
+
+#### Properties
+
+| Property   | Type      | Required | Description                                                         | Comments                                  |
+| ---------- | --------- | -------- | ------------------------------------------------------------------- | ----------------------------------------- |
+| `gap`      | `integer` | ❌       | Gap between images in pixels.                                       |                                           |
+| `format`   | `string`  | ❌       |                                                                     | Known values: `grid`, `carousel`, `strip` |
+| `images`   | `ref[]`   | ✅       |                                                                     |                                           |
+| `maxWidth` | `integer` | ❌       | Max width per image in grid view (px); drives how many columns fit. |                                           |
+
+#### Defs
+
+##### `pub.leaflet.blocks.imageGallery#image`
+
+| Property      | Type     | Required | Description                                           | Comments                             |
+| ------------- | -------- | -------- | ----------------------------------------------------- | ------------------------------------ |
+| `alt`         | `string` | ❌       | Alt text description of the image, for accessibility. |                                      |
+| `image`       | `blob`   | ✅       |                                                       | maxSize: 1000000, accepts: `image/*` |
+| `aspectRatio` | `ref`    | ✅       |                                                       |                                      |
+
+##### `pub.leaflet.blocks.imageGallery#aspectRatio`
 
 | Property | Type      | Required | Description |
 | -------- | --------- | -------- | ----------- |
@@ -965,6 +1028,14 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 | Property | Type     | Required | Description |
 | -------- | -------- | -------- | ----------- |
 | `tex`    | `string` | ✅       |             |
+
+---
+
+### `pub.leaflet.blocks.membersOnlyDelimiter`
+
+**Description:** Marks where members-only content begins; blocks after this delimiter are only served to readers with an active paid membership.
+
+#### Properties
 
 ---
 
@@ -1007,6 +1078,52 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 | Property  | Type  | Required | Description |
 | --------- | ----- | -------- | ----------- |
 | `pollRef` | `ref` | ✅       |             |
+
+---
+
+### `pub.leaflet.blocks.postsList`
+
+#### Properties
+
+| Property             | Type       | Required | Description                   | Comments                        |
+| -------------------- | ---------- | -------- | ----------------------------- | ------------------------------- |
+| `view`               | `string`   | ❌       |                               | Known values: `small`, `medium` |
+| `limit`              | `integer`  | ❌       | Show at most this many posts. | minimum: 1                      |
+| `filterByTags`       | `string[]` | ❌       |                               |                                 |
+| `highlightFirstPost` | `boolean`  | ❌       |                               |                                 |
+
+---
+
+### `pub.leaflet.blocks.signup`
+
+**Description:** A subscribe/signup form for the publication. Renders the publication's subscribe form; carries no configurable data.
+
+#### Properties
+
+---
+
+### `pub.leaflet.blocks.standardSitePost`
+
+#### Properties
+
+| Property               | Type      | Required | Description | Comments                                 |
+| ---------------------- | --------- | -------- | ----------- | ---------------------------------------- |
+| `cid`                  | `string`  | ❌       |             |                                          |
+| `uri`                  | `string`  | ✅       |             |                                          |
+| `size`                 | `string`  | ❌       |             | Known values: `large`, `medium`, `small` |
+| `showPublicationTheme` | `boolean` | ❌       |             |                                          |
+
+---
+
+### `pub.leaflet.blocks.standardSitePublication`
+
+#### Properties
+
+| Property               | Type      | Required | Description |
+| ---------------------- | --------- | -------- | ----------- |
+| `cid`                  | `string`  | ❌       |             |
+| `uri`                  | `string`  | ✅       |             |
+| `showPublicationTheme` | `boolean` | ❌       |             |
 
 ---
 
@@ -1107,10 +1224,10 @@ Configuration for a specific contributor within a board. Values serve as fallbac
 
 Specifies the sub-string range a facet feature applies to. Start index is inclusive, end index is exclusive. Indices are zero-indexed, counting bytes of the UTF-8 encoded text. NOTE: some languages, like Javascript, use UTF-16 or Unicode codepoints for string slice indexing; in these languages, convert to byte arrays before working with facets.
 
-| Property    | Type      | Required | Description |
-| ----------- | --------- | -------- | ----------- |
-| `byteStart` | `integer` | ✅       |             |
-| `byteEnd`   | `integer` | ✅       |             |
+| Property    | Type      | Required | Description | Comments   |
+| ----------- | --------- | -------- | ----------- | ---------- |
+| `byteStart` | `integer` | ✅       |             | minimum: 0 |
+| `byteEnd`   | `integer` | ✅       |             | minimum: 0 |
 
 ##### `pub.leaflet.richtext.facet#link`
 
@@ -1135,6 +1252,7 @@ Facet feature for mentioning an AT URI.
 | Property | Type     | Required | Description |
 | -------- | -------- | -------- | ----------- |
 | `atURI`  | `string` | ✅       |             |
+| `href`   | `string` | ❌       |             |
 
 ##### `pub.leaflet.richtext.facet#code`
 
@@ -1143,6 +1261,10 @@ Facet feature for inline code.
 ##### `pub.leaflet.richtext.facet#highlight`
 
 Facet feature for highlighted text.
+
+| Property | Type    | Required | Description |
+| -------- | ------- | -------- | ----------- |
+| `color`  | `union` | ❌       |             |
 
 ##### `pub.leaflet.richtext.facet#underline`
 
@@ -1177,6 +1299,29 @@ Facet feature for a footnote reference
 | `footnoteId`       | `string` | ✅       |             |
 | `contentPlaintext` | `string` | ✅       |             |
 | `contentFacets`    | `ref[]`  | ❌       |             |
+
+---
+
+### `pub.leaflet.theme.color`
+
+#### Defs
+
+##### `pub.leaflet.theme.color#rgb`
+
+| Property | Type      | Required | Description | Comments                 |
+| -------- | --------- | -------- | ----------- | ------------------------ |
+| `b`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
+| `g`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
+| `r`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
+
+##### `pub.leaflet.theme.color#rgba`
+
+| Property | Type      | Required | Description | Comments                 |
+| -------- | --------- | -------- | ----------- | ------------------------ |
+| `a`      | `integer` | ✅       |             | minimum: 0, maximum: 100 |
+| `b`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
+| `g`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
+| `r`      | `integer` | ✅       |             | minimum: 0, maximum: 255 |
 
 ---
 

--- a/lexicons/pub/leaflet/blocks/html.json
+++ b/lexicons/pub/leaflet/blocks/html.json
@@ -1,17 +1,14 @@
 {
   "lexicon": 1,
-  "id": "pub.leaflet.blocks.iframe",
+  "id": "pub.leaflet.blocks.html",
   "defs": {
     "main": {
       "type": "object",
+      "required": ["html"],
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri"
-        },
         "html": {
           "type": "string",
-          "description": "DEPRECATED — use pub.leaflet.blocks.html instead. Inline HTML rendered via the iframe's srcdoc attribute. Takes precedence over url."
+          "description": "Inline HTML rendered via a sandboxed iframe's srcdoc attribute."
         },
         "height": {
           "type": "integer",

--- a/lexicons/pub/leaflet/blocks/image.json
+++ b/lexicons/pub/leaflet/blocks/image.json
@@ -22,6 +22,10 @@
         "fullBleed": {
           "type": "boolean",
           "description": "Whether the image should extend to the full width of the container, ignoring padding."
+        },
+        "width": {
+          "type": "integer",
+          "description": "Display width of the image in pixels, capped at the page width."
         }
       }
     },

--- a/lexicons/pub/leaflet/blocks/imageGallery.json
+++ b/lexicons/pub/leaflet/blocks/imageGallery.json
@@ -1,0 +1,62 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.imageGallery",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["images"],
+      "properties": {
+        "gap": {
+          "type": "integer",
+          "description": "Gap between images in pixels."
+        },
+        "format": {
+          "type": "string",
+          "knownValues": ["grid", "carousel", "strip"]
+        },
+        "images": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#image"
+          }
+        },
+        "maxWidth": {
+          "type": "integer",
+          "description": "Max width per image in grid view (px); drives how many columns fit."
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["image", "aspectRatio"],
+      "properties": {
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "image": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 1000000
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "#aspectRatio"
+        }
+      }
+    },
+    "aspectRatio": {
+      "type": "object",
+      "required": ["width", "height"],
+      "properties": {
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/leaflet/blocks/membersOnlyDelimiter.json
+++ b/lexicons/pub/leaflet/blocks/membersOnlyDelimiter.json
@@ -1,0 +1,12 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.membersOnlyDelimiter",
+  "defs": {
+    "main": {
+      "type": "object",
+      "description": "Marks where members-only content begins; blocks after this delimiter are only served to readers with an active paid membership.",
+      "required": [],
+      "properties": {}
+    }
+  }
+}

--- a/lexicons/pub/leaflet/blocks/postsList.json
+++ b/lexicons/pub/leaflet/blocks/postsList.json
@@ -1,0 +1,30 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.postsList",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "view": {
+          "type": "string",
+          "knownValues": ["small", "medium"]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Show at most this many posts."
+        },
+        "filterByTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "highlightFirstPost": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/leaflet/blocks/signup.json
+++ b/lexicons/pub/leaflet/blocks/signup.json
@@ -1,0 +1,12 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.signup",
+  "defs": {
+    "main": {
+      "type": "object",
+      "description": "A subscribe/signup form for the publication. Renders the publication's subscribe form; carries no configurable data.",
+      "required": [],
+      "properties": {}
+    }
+  }
+}

--- a/lexicons/pub/leaflet/blocks/standardSitePost.json
+++ b/lexicons/pub/leaflet/blocks/standardSitePost.json
@@ -1,0 +1,26 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.standardSitePost",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "cid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "size": {
+          "type": "string",
+          "knownValues": ["large", "medium", "small"]
+        },
+        "showPublicationTheme": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/leaflet/blocks/standardSitePublication.json
+++ b/lexicons/pub/leaflet/blocks/standardSitePublication.json
@@ -1,0 +1,22 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.blocks.standardSitePublication",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["uri"],
+      "properties": {
+        "cid": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "at-uri"
+        },
+        "showPublicationTheme": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/lexicons/pub/leaflet/pages/linearDocument.json
+++ b/lexicons/pub/leaflet/pages/linearDocument.json
@@ -26,10 +26,12 @@
           "type": "union",
           "refs": [
             "pub.leaflet.blocks.iframe",
+            "pub.leaflet.blocks.html",
             "pub.leaflet.blocks.text",
             "pub.leaflet.blocks.blockquote",
             "pub.leaflet.blocks.header",
             "pub.leaflet.blocks.image",
+            "pub.leaflet.blocks.imageGallery",
             "pub.leaflet.blocks.unorderedList",
             "pub.leaflet.blocks.orderedList",
             "pub.leaflet.blocks.website",
@@ -37,9 +39,14 @@
             "pub.leaflet.blocks.code",
             "pub.leaflet.blocks.horizontalRule",
             "pub.leaflet.blocks.bskyPost",
+            "pub.leaflet.blocks.standardSitePost",
+            "pub.leaflet.blocks.standardSitePublication",
             "pub.leaflet.blocks.page",
             "pub.leaflet.blocks.poll",
-            "pub.leaflet.blocks.button"
+            "pub.leaflet.blocks.button",
+            "pub.leaflet.blocks.postsList",
+            "pub.leaflet.blocks.signup",
+            "pub.leaflet.blocks.membersOnlyDelimiter"
           ]
         },
         "alignment": {

--- a/lexicons/pub/leaflet/richtext/facet.json
+++ b/lexicons/pub/leaflet/richtext/facet.json
@@ -76,6 +76,10 @@
         "atURI": {
           "type": "string",
           "format": "uri"
+        },
+        "href": {
+          "type": "string",
+          "format": "uri"
         }
       }
     },
@@ -89,7 +93,15 @@
       "type": "object",
       "description": "Facet feature for highlighted text.",
       "required": [],
-      "properties": {}
+      "properties": {
+        "color": {
+          "type": "union",
+          "refs": [
+            "pub.leaflet.theme.color#rgba",
+            "pub.leaflet.theme.color#rgb"
+          ]
+        }
+      }
     },
     "underline": {
       "type": "object",

--- a/lexicons/pub/leaflet/theme/color.json
+++ b/lexicons/pub/leaflet/theme/color.json
@@ -1,0 +1,53 @@
+{
+  "lexicon": 1,
+  "id": "pub.leaflet.theme.color",
+  "defs": {
+    "rgb": {
+      "type": "object",
+      "required": ["r", "g", "b"],
+      "properties": {
+        "b": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "g": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "r": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      }
+    },
+    "rgba": {
+      "type": "object",
+      "required": ["r", "g", "b", "a"],
+      "properties": {
+        "a": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "b": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "g": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "r": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-schemas.js
+++ b/scripts/generate-schemas.js
@@ -87,6 +87,8 @@ function getTypeString(prop) {
 
 function getComments(prop) {
   const comments = [];
+  if (prop.minimum !== undefined) comments.push(`minimum: ${prop.minimum}`);
+  if (prop.maximum !== undefined) comments.push(`maximum: ${prop.maximum}`);
   if (prop.maxLength) comments.push(`maxLength: ${prop.maxLength}`);
   if (prop.maxGraphemes) comments.push(`maxGraphemes: ${prop.maxGraphemes}`);
   if (prop.maxSize) comments.push(`maxSize: ${prop.maxSize}`);

--- a/tests/validate-external-lexicons.test.ts
+++ b/tests/validate-external-lexicons.test.ts
@@ -163,3 +163,57 @@ describe("external lexicon validation: pub.leaflet + app.bsky.richtext", () => {
     });
   });
 });
+
+describe("published Leaflet schema updates", () => {
+  it("accepts an iframe with an aspect ratio and no URL", () => {
+    const result = validate(
+      {
+        $type: "pub.leaflet.blocks.iframe",
+        aspectRatio: { width: 16, height: 9 },
+      },
+      ids.PubLeafletBlocksIframe,
+      "main",
+      true,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("registers the posts list block and enforces its minimum limit", () => {
+    expect((ids as Record<string, string>).PubLeafletBlocksPostsList).toBe(
+      "pub.leaflet.blocks.postsList",
+    );
+
+    let result: ReturnType<typeof validate> | undefined;
+
+    expect(() => {
+      result = validate(
+        { limit: 0 },
+        "pub.leaflet.blocks.postsList",
+        "main",
+        true,
+      );
+    }).not.toThrow();
+
+    expect(result?.success).toBe(false);
+  });
+
+  it("registers Leaflet theme colors and enforces RGB channel bounds", () => {
+    expect((ids as Record<string, string>).PubLeafletThemeColor).toBe(
+      "pub.leaflet.theme.color",
+    );
+
+    let result: ReturnType<typeof validate> | undefined;
+
+    expect(() => {
+      result = validate(
+        { r: 256, g: 0, b: 0 },
+        "pub.leaflet.theme.color",
+        "rgb",
+        true,
+      );
+    }).not.toThrow();
+
+    expect(result?.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- sync the vendored `pub.leaflet.*` schema graph with the published Leaflet Lexicons
- add eight newly referenced block and theme schemas
- update iframe, image, linear document, and rich-text facet schemas
- include numeric minimum and maximum constraints in generated schema documentation
- add a major changeset because `iframe.url` becomes optional in generated TypeScript


## Validation

*Checked 2,277 existing Leaflet documents: 2,275 were valid before and remain valid, while the same 2 were invalid before and after—so this update breaks none.*

- `npm run check` — 203 tests passed; formatting, ESLint, typecheck, and build passed
- `npm run style:check` — passed with no errors
- verified all 25 vendored Leaflet schemas against the fetched published records


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Leaflet blocks for HTML, image galleries, post lists, signups, members-only sections, and standard posts/publications.
  * Expanded iframe and image blocks with flexible sizing, aspect ratios, and optional content.
  * Added RGB/RGBA theme colors and highlighted text color support.
  * Added optional links for rich-text mentions.
* **Improvements**
  * Added clearer validation limits for dimensions, opacity, headings, and byte positions.
  * Updated schema references to document the new capabilities and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->